### PR TITLE
fix: remove system-prompt-marker guard from OAuth request shaping

### DIFF
--- a/src/request-shaping.ts
+++ b/src/request-shaping.ts
@@ -3,9 +3,7 @@ import {
   BILLING_HEADER_POSITIONS,
   BILLING_HEADER_SALT,
   CLAUDE_CODE_ENTRYPOINT,
-  CLAUDE_CODE_IDENTITY_PREFIX,
   CLAUDE_CODE_VERSION,
-  MINIMAL_ANTHROPIC_OAUTH_PROMPT_PREFIX,
 } from "./constants.js";
 import { debugLog, isToolUseOnlyDebugEnabled } from "./debug.js";
 import { shapeSystemBlocks } from "./system-prompt-shaping.js";
@@ -49,30 +47,6 @@ function isAnthropicMessagesPayload(
     typeof payload.model === "string" &&
     Array.isArray(payload.messages) &&
     typeof payload.stream === "boolean"
-  );
-}
-
-function isOAuthAnthropicPayload(payload: AnthropicPayload): boolean {
-  if (!Array.isArray(payload.system)) {
-    return false;
-  }
-
-  return payload.system.some(hasOAuthAnthropicSystemMarker);
-}
-
-function hasOAuthAnthropicSystemMarker(block: unknown): boolean {
-  if (
-    !isRecord(block) ||
-    block.type !== "text" ||
-    typeof block.text !== "string"
-  ) {
-    return false;
-  }
-
-  return (
-    block.text.includes(CLAUDE_CODE_IDENTITY_PREFIX) ||
-    block.text.includes("x-anthropic-billing-header:") ||
-    block.text.startsWith(MINIMAL_ANTHROPIC_OAUTH_PROMPT_PREFIX)
   );
 }
 
@@ -255,9 +229,21 @@ export function shapeAnthropicOAuthPayload(payload: unknown): unknown {
   }
 
   const messages = payload.messages as MessageParam[];
-  if (!isOAuthAnthropicPayload(payload)) {
-    return payload;
-  }
+
+  // NOTE: We intentionally skip the isOAuthAnthropicPayload() guard.
+  //
+  // The old guard relied on detecting system prompt markers like
+  // "You are Claude Code, Anthropic's official CLI" that Pi's built-in
+  // provider injects for OAuth sessions.  In fork children (print/json mode),
+  // these markers may be absent, causing the shaping to be skipped and
+  // Anthropic to classify the request as a third-party app (400 error).
+  //
+  // Since this extension is only installed for OAuth usage, the extension
+  // being loaded is itself the signal that requests should be shaped.
+  // The individual shaping operations are safely guarded:
+  //   - shapeSystemBlocks: only modifies blocks with PI_DEFAULT_PROMPT_PREFIX
+  //   - prependBillingHeader: skips if already present
+  //   - splitAssistantToolUseTrailingContent: safe for all messages
 
   const normalizedMessages = splitAssistantToolUseTrailingContent(messages);
 

--- a/test/request-shaping.test.ts
+++ b/test/request-shaping.test.ts
@@ -59,7 +59,7 @@ function createOAuthPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
-test("shapes only OAuth Anthropic payloads", () => {
+test("shapes all Anthropic payloads regardless of system prompt markers", () => {
   const payload = {
     model: TEST_MODEL,
     stream: true,
@@ -67,9 +67,13 @@ test("shapes only OAuth Anthropic payloads", () => {
     system: [{ type: "text", text: "Generic system prompt." }],
   };
 
-  const shaped = shapeAnthropicOAuthPayload(payload);
+  const shaped = shapeAnthropicOAuthPayload(payload) as typeof payload;
+  const systemBlocks = shaped.system as Array<{ text: string }>;
 
-  assert.equal(shaped, payload);
+  // Billing header is prepended even without OAuth markers
+  assert.ok(systemBlocks[0]?.text.includes("x-anthropic-billing-header:"));
+  // Original system block is preserved
+  assert.equal(systemBlocks[1]?.text, "Generic system prompt.");
 });
 
 test("prepends the billing header block without adding cache control on OAuth payloads", () => {
@@ -240,7 +244,7 @@ test("shapes Pi default system prompt in OAuth payloads", () => {
   );
 });
 
-test("does not shape system prompt in non-OAuth payloads", () => {
+test("shapes system prompt in all Anthropic payloads (fork child compatibility)", () => {
   const piDefaultPrompt =
     "You are an expert coding assistant operating inside pi, a coding agent harness. You help users.";
   const payload = {
@@ -255,10 +259,17 @@ test("does not shape system prompt in non-OAuth payloads", () => {
     ],
   };
 
-  const shaped = shapeAnthropicOAuthPayload(payload);
+  const shaped = shapeAnthropicOAuthPayload(payload) as typeof payload;
+  const systemBlocks = shaped.system as Array<{ text: string }>;
 
-  // Non-OAuth payload is returned unchanged
-  assert.equal(shaped, payload);
+  // Billing header is prepended
+  assert.ok(systemBlocks[0]?.text.includes("x-anthropic-billing-header:"));
+  // Pi preamble identity is removed from the system block
+  assert.ok(
+    !systemBlocks[1]?.text.includes(
+      "operating inside pi, a coding agent harness",
+    ),
+  );
 });
 
 test("shapes OAuth payloads detected by the minimal neutral system prompt marker", () => {


### PR DESCRIPTION
## Problem

When `pi-anthropic-auth` is used together with `pi-fork`, fork children get HTTP 400 errors from Anthropic:

> Third-party apps now draw from your extra usage, not your plan limits.

The root cause is `isOAuthAnthropicPayload()` in `request-shaping.ts` — it checks for system prompt markers like `"You are Claude Code, Anthropic's official CLI"` to decide whether to shape the request. Fork children running in `-p --mode json` mode don't have these markers injected by Pi's built-in provider, so the shaping is skipped entirely. The request goes to Anthropic with an OAuth token but no billing headers or prompt shaping → classified as third-party app → 400.

## Fix

Remove the `isOAuthAnthropicPayload()` guard. The extension being loaded is itself the signal that OAuth is active — no need to detect it from system prompt content.

All individual shaping operations are already safely guarded:
- `shapeSystemBlocks`: only modifies blocks containing `PI_DEFAULT_PROMPT_PREFIX`
- `prependBillingHeader`: skips if a billing header is already present
- `splitAssistantToolUseTrailingContent`: safe for all messages

## Testing

- All 39 existing tests pass (2 updated to match new behavior)
- Typecheck and build clean
- Verified with `pi-fork` at all effort levels (fast/balanced/deep) — no 400 errors
- Verified `pi-observational-memory` compaction model on Anthropic — works

## Changes

- `src/request-shaping.ts`: removed `isOAuthAnthropicPayload()`, `hasOAuthAnthropicSystemMarker()`, and unused imports
- `test/request-shaping.test.ts`: updated 2 tests to assert new unconditional shaping behavior