### PR TITLE
fix: set usesCallbackServer on anthropicOAuthOverride

### DIFF
--- a/src/anthropic-oauth.ts
+++ b/src/anthropic-oauth.ts
@@ -24,6 +24,7 @@ export function mergeRefreshedCredentials(
 
 export const anthropicOAuthOverride = {
   name: "Anthropic (Claude Pro/Max)",
+  usesCallbackServer: true,
   login(callbacks: OAuthLoginCallbacks): Promise<OAuthCredentials> {
     return loginAnthropic(callbacks);
   },


### PR DESCRIPTION
## Problem

When this extension registers via `pi.registerProvider("anthropic", { oauth: anthropicOAuthOverride })`, it replaces the built-in Anthropic OAuth provider. The built-in provider has `usesCallbackServer: true`, but `anthropicOAuthOverride` omits it.

Pi's interactive TUI checks `providerInfo?.usesCallbackServer ?? false` to decide whether to render the manual redirect-URL paste input alongside the auth URL. With the flag missing, it defaults to `false` and never shows the input — leaving the login flow frozen waiting for a browser callback that can never arrive when the local callback server is unreachable (Docker containers, SSH sessions, remote dev environments).

## Fix

Add `usesCallbackServer: true` to `anthropicOAuthOverride`. The field is already optional on `Omit<OAuthProviderInterface, "id">` so no type changes are needed.

## Testing

Verified with a red-green cycle inside a Docker container (where `localhost:53692` is unreachable):

- **Without fix**: `/login anthropic` shows the auth URL then freezes — no input field, no way to cancel
- **With fix**: an input field appears immediately below the URL allowing the redirect URL to be pasted manually