### PR TITLE
fix: walk parent node_modules to resolve pi-ai, bypassing jiti import.meta.resolve

### DIFF
--- a/src/host-transport.ts
+++ b/src/host-transport.ts
@@ -1,3 +1,4 @@
+import { access } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import type {
@@ -29,6 +30,35 @@ export type AnthropicStreamSimpleDelegate = StreamFunction<
 const ANTHROPIC_PROVIDER_RELATIVE_PATH = "dist/providers/anthropic.js";
 
 /**
+ * Walks up the directory tree from `startDir`, checking for
+ * `node_modules/<packageName>` at each level.
+ *
+ * This mirrors Node.js's native CommonJS module resolution traversal and
+ * works regardless of how the loader (jiti) handles `import.meta.resolve`.
+ * In particular, when this extension is installed via `pi install`, the host
+ * `@earendil-works/pi-ai` package lives in a parent `node_modules` directory
+ * rather than the extension's own — a location that jiti's
+ * `import.meta.resolve` fails to reach (Issue #31).
+ */
+async function findNearestPackageDir(
+  packageName: string,
+  startDir: string,
+): Promise<string | null> {
+  let current = startDir;
+  while (true) {
+    const candidate = join(current, "node_modules", packageName);
+    try {
+      await access(candidate);
+      return candidate;
+    } catch {
+      const parent = dirname(current);
+      if (parent === current) return null; // reached filesystem root
+      current = parent;
+    }
+  }
+}
+
+/**
  * Resolves Pi's built-in Anthropic `streamSimple` transport at runtime.
  *
  * A static `import { streamSimpleAnthropic } from "@earendil-works/pi-ai/anthropic"`
@@ -39,27 +69,44 @@ const ANTHROPIC_PROVIDER_RELATIVE_PATH = "dist/providers/anthropic.js";
  * subpath import into `dist/index.js/anthropic` — a nonexistent path — and
  * `import.meta.resolve("@earendil-works/pi-ai/anthropic")` fails the same way.
  *
- * `import.meta.resolve("@earendil-works/pi-ai")` *does* resolve (jiti's alias
- * handles the bare specifier), so this helper resolves the root entry, derives
- * the package directory, and dynamically imports the concrete provider file —
- * the same file the `exports` `./anthropic` subpath points at.  That yields
- * the real `streamSimpleAnthropic`, not pi-ai 0.79.8's lazy registry stub
- * (see Issue #28).
+ * Previously this helper used `import.meta.resolve("@earendil-works/pi-ai")`
+ * to locate the package root.  That worked in local dev (where the package is
+ * a dev dependency and present in the extension's own `node_modules`) but
+ * failed when the extension was installed via `pi install npm:...`: Pi's
+ * package installer runs `npm install --omit=dev`, so only `dependencies` are
+ * installed.  `@earendil-works/pi-ai` is a peer/dev dependency, so it is
+ * absent from the extension's own `node_modules` tree, and jiti's
+ * `import.meta.resolve` cannot reach the copy that lives in Pi's shared
+ * `node_modules` directory (Issue #31).
+ *
+ * The fix is a manual filesystem walk (`findNearestPackageDir`) that climbs
+ * parent directories until it finds `node_modules/@earendil-works/pi-ai`,
+ * mirroring what Node.js's own resolution algorithm does.  This is independent
+ * of the loader, so it works in both local dev and `pi install` environments.
  *
  * Resolving the delegate this way (rather than capturing it from the API
  * registry) is what keeps our `streamSimple` wrapper from being clobbered by
- * the lazy stub's first-call `register()`.
+ * the lazy stub's first-call `register()` (Issue #28).
  *
  * @returns the built-in `streamSimpleAnthropic` transport.
- * @throws when the root package cannot be resolved or the provider module
+ * @throws when the package cannot be found or the provider module
  *   does not export `streamSimpleAnthropic` (e.g. a future pi-ai layout
  *   change).
  */
 export async function resolveBuiltinAnthropicStreamSimple(): Promise<AnthropicStreamSimpleDelegate> {
-  const rootUrl = import.meta.resolve("@earendil-works/pi-ai");
-  const rootFile = fileURLToPath(rootUrl);
-  // `<pkg>/dist/index.js` → `<pkg>/dist` → `<pkg>`.
-  const packageDir = dirname(dirname(rootFile));
+  const startDir = dirname(fileURLToPath(import.meta.url));
+  const packageDir = await findNearestPackageDir(
+    "@earendil-works/pi-ai",
+    startDir,
+  );
+
+  if (packageDir === null) {
+    throw new Error(
+      "Could not find @earendil-works/pi-ai in any parent node_modules directory. " +
+        "Ensure @earendil-works/pi-ai is installed alongside this extension.",
+    );
+  }
+
   // `pathToFileURL` (not `new URL(path, "file:///")`) percent-encodes path
   // components, so an install path containing `#` or `?` resolves correctly.
   const providerModuleUrl = pathToFileURL(


### PR DESCRIPTION
## Problem

Closes #31.

When installed via `pi install npm:@gotgenes/pi-anthropic-auth`, the extension fails immediately on startup:

```
Error: Failed to load extension ".../node_modules/@gotgenes/pi-anthropic-auth/src/index.ts":
Cannot find module '@earendil-works/pi-ai'
from '.../node_modules/@gotgenes/pi-anthropic-auth/src/host-transport.ts'
```

`host-transport.ts` calls `import.meta.resolve("@earendil-works/pi-ai")` to locate the package root and then dynamically import `dist/providers/anthropic.js`. This works in local dev because `@earendil-works/pi-ai` is a devDependency and present in the extension's own `node_modules`. But `pi install` runs `npm install --omit=dev`, so only `dependencies` are installed — `@earendil-works/pi-ai` (peer/dev only) is never installed in the extension's own tree, and jiti's `import.meta.resolve` cannot reach the copy that lives in Pi's shared parent `node_modules`.

## Fix

Replace `import.meta.resolve("@earendil-works/pi-ai")` with a manual filesystem walk (`findNearestPackageDir`) that climbs parent directories checking for `node_modules/@earendil-works/pi-ai` at each level — exactly what Node.js's own module resolution algorithm does. This is loader-independent and finds the package whether it's in the extension's own `node_modules` (local dev) or a parent directory (pi install).

Example traversal from the pi install location:

```
.../node_modules/@gotgenes/pi-anthropic-auth/src/       → no
.../node_modules/@gotgenes/pi-anthropic-auth/           → no
.../node_modules/@gotgenes/                             → no
.../node_modules/                                       → no
.../.pi/agent/npm/node_modules/@earendil-works/pi-ai    → ✓ found
```

## Testing

Verified fix resolves the load error with `pi install npm:@gotgenes/pi-anthropic-auth` on pi 0.79.10. Local dev (`pi -e /path/to/src/index.ts`) continues to work as before since the devDependency is found in the first few steps of the traversal.