### PR TITLE
fix: suppress Anthropic OAuth extra-usage warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ pi -e npm:@gotgenes/pi-anthropic-auth
 2. Select a Claude Pro/Max model and start chatting. The extension handles compatibility transparently.
 3. API-key behavior is unaffected; the extension's changes apply only to OAuth sessions.
 
+### Anthropic extra-usage warning
+
+After the extension loads successfully, it sets Pi's global
+`warnings.anthropicExtraUsage` preference to `false`. This hides Pi's generic
+OAuth extra-usage warning on the next Pi startup; it does **not** change how
+Anthropic bills or classifies requests.
+
 ## Troubleshooting
 
 ### Verify the extension is loaded

--- a/src/anthropic-extra-usage-warning.ts
+++ b/src/anthropic-extra-usage-warning.ts
@@ -1,0 +1,29 @@
+import type { SettingsManager } from "@earendil-works/pi-coding-agent";
+
+export type WarningSettingsManager = Pick<
+  SettingsManager,
+  "getWarnings" | "setWarnings"
+>;
+
+/**
+ * Suppresses Pi's OAuth extra-usage warning once pi-anthropic-auth has loaded.
+ *
+ * The warning is presentation-only: changing it does not change Anthropic
+ * billing. Preserve all other warning preferences while disabling this one.
+ *
+ * @returns Whether the setting was changed.
+ */
+export function disableAnthropicExtraUsageWarning(
+  settingsManager: WarningSettingsManager,
+): boolean {
+  const warnings = settingsManager.getWarnings();
+  if (warnings.anthropicExtraUsage === false) {
+    return false;
+  }
+
+  settingsManager.setWarnings({
+    ...warnings,
+    anthropicExtraUsage: false,
+  });
+  return true;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,10 @@
 import { fileURLToPath } from "node:url";
-import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import {
+  type ExtensionAPI,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import { disableAnthropicExtraUsageWarning } from "./anthropic-extra-usage-warning";
+import { debugLog } from "./debug";
 import {
   createStatusCommandHandler,
   type ExtensionDiagnostics,
@@ -70,6 +75,17 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     api: "anthropic-messages",
     streamSimple: createAnthropicOAuthStreamSimple(streamSimpleAnthropic),
   });
+
+  // Pi shows its generic OAuth extra-usage warning whenever Anthropic OAuth is
+  // active, including after this wrapper has registered. The warning is only a
+  // UI preference and does not control or alter Anthropic billing.
+  try {
+    disableAnthropicExtraUsageWarning(SettingsManager.create(process.cwd()));
+  } catch (error) {
+    debugLog("disable-anthropic-extra-usage-warning-failed", {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   // The /anthropic-auth:status command surfaces the loaded version, module
   // path, and transport resolution result so users can confirm the extension

--- a/test/anthropic-extra-usage-warning.test.ts
+++ b/test/anthropic-extra-usage-warning.test.ts
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import {
+  disableAnthropicExtraUsageWarning,
+  type WarningSettingsManager,
+} from "#src/anthropic-extra-usage-warning";
+
+describe("disableAnthropicExtraUsageWarning", () => {
+  test("disables the warning while preserving other preferences", () => {
+    const setWarnings = vi.fn();
+    const settingsManager = {
+      getWarnings: () => ({ otherWarning: true }),
+      setWarnings,
+    };
+
+    const changed = disableAnthropicExtraUsageWarning(
+      settingsManager as WarningSettingsManager,
+    );
+
+    assert.equal(changed, true);
+    assert.deepEqual(setWarnings.mock.calls, [
+      [{ otherWarning: true, anthropicExtraUsage: false }],
+    ]);
+  });
+
+  test("does not rewrite settings when the warning is already disabled", () => {
+    const setWarnings = vi.fn();
+    const settingsManager = {
+      getWarnings: () => ({ anthropicExtraUsage: false }),
+      setWarnings,
+    };
+
+    const changed = disableAnthropicExtraUsageWarning(settingsManager);
+
+    assert.equal(changed, false);
+    assert.equal(setWarnings.mock.calls.length, 0);
+  });
+});

--- a/test/index-registration.test.ts
+++ b/test/index-registration.test.ts
@@ -42,7 +42,12 @@ const CONTEXT = { messages: [] } as unknown as Context;
  * declarations, which would otherwise leave the stub `undefined` when the
  * factory runs.
  */
-const { delegateCalls, streamSimpleAnthropicMock } = vi.hoisted(() => {
+const {
+  delegateCalls,
+  disableAnthropicExtraUsageWarningMock,
+  settingsManagerCreateMock,
+  streamSimpleAnthropicMock,
+} = vi.hoisted(() => {
   const delegateCalls: Array<{ options?: SimpleStreamOptions }> = [];
   const streamSimpleAnthropicMock: Mock<
     (
@@ -54,7 +59,14 @@ const { delegateCalls, streamSimpleAnthropicMock } = vi.hoisted(() => {
     delegateCalls.push({ options });
     return createAssistantMessageEventStream();
   });
-  return { delegateCalls, streamSimpleAnthropicMock };
+  const disableAnthropicExtraUsageWarningMock = vi.fn();
+  const settingsManagerCreateMock = vi.fn(() => ({}));
+  return {
+    delegateCalls,
+    disableAnthropicExtraUsageWarningMock,
+    settingsManagerCreateMock,
+    streamSimpleAnthropicMock,
+  };
 });
 
 vi.mock("#src/host-transport", () => ({
@@ -63,6 +75,14 @@ vi.mock("#src/host-transport", () => ({
     // satisfies it structurally (the registry only ever invokes it for
     // `anthropic-messages` models).
     Promise.resolve(streamSimpleAnthropicMock),
+}));
+
+vi.mock("#src/anthropic-extra-usage-warning", () => ({
+  disableAnthropicExtraUsageWarning: disableAnthropicExtraUsageWarningMock,
+}));
+
+vi.mock("@earendil-works/pi-coding-agent", () => ({
+  SettingsManager: { create: settingsManagerCreateMock },
 }));
 
 /**
@@ -188,6 +208,8 @@ describe("index registration: wrapper survives a re-register clobber (#28 regres
   beforeEach(() => {
     resetApiProviders();
     delegateCalls.length = 0;
+    disableAnthropicExtraUsageWarningMock.mockClear();
+    settingsManagerCreateMock.mockClear();
     streamSimpleAnthropicMock.mockClear();
 
     // Seed the registry with the lazy-stub, simulating a provider that
@@ -248,6 +270,8 @@ describe("index registration: wrapper survives a re-register clobber (#28 regres
       ["unregister:anthropic", "register:anthropic"],
       "unregisterProvider('anthropic') must run before registerProvider so a co-loaded stale copy's oauth cannot survive the merge",
     );
+    assert.equal(disableAnthropicExtraUsageWarningMock.mock.calls.length, 1);
+    assert.equal(settingsManagerCreateMock.mock.calls.length, 1);
   });
 });
 
@@ -255,6 +279,8 @@ describe("index registration: diagnostics command", () => {
   beforeEach(() => {
     resetApiProviders();
     delegateCalls.length = 0;
+    disableAnthropicExtraUsageWarningMock.mockClear();
+    settingsManagerCreateMock.mockClear();
     streamSimpleAnthropicMock.mockClear();
     registerApiProvider({
       api: "anthropic-messages",


### PR DESCRIPTION
## Summary

- Disable Pi's generic Anthropic OAuth extra-usage warning after `pi-anthropic-auth` registers successfully.
- Preserve other warning preferences and leave OAuth transport, authentication, and billing behavior unchanged.
- Document that the change takes effect on the next Pi startup.

## Validation

- `pnpm test` (54 tests)
- `pnpm check`
- `pnpm lint`
- Independent focused review: PASS at `53bce71186d3ed4a2d2b6e1d298d1c41909711d1`

The PR intentionally does not close #42: that report concerns extension auto-loading, whereas this change handles Pi's separate generic OAuth warning.