### PR TITLE
feat: add Anthropic OAuth usage dashboard

### DIFF
--- a/PR.md
+++ b/PR.md
@@ -42,6 +42,23 @@ The implementation does not use Claude web cookies, browser sessions, DOM scrapi
 
 OAuth access and refresh tokens are never included in command output, logs, or persisted snapshots.
 
+## Undocumented endpoint risk
+
+Both endpoints are undocumented Anthropic OAuth control-plane endpoints. That means field shapes and availability can change without notice.
+
+The implementation is designed to tolerate that:
+
+- All response fields are optional. Missing or unrecognized fields are silently ignored, not treated as zero usage.
+- Unknown `limits[]` window types render with their raw label rather than failing.
+- `decimal_places` and minor-unit exponents are read from the response; the rendering scales with whatever Anthropic returns rather than hard-coding assumptions.
+- If the profile endpoint fails, the Usage tab still renders with a warning — enrichment is best-effort, not required.
+- If a token refresh fails mid-session, the last successful snapshot is shown as stale instead of clearing the display.
+- All HTTP error codes (401, 403, 429, 5xx) produce user-facing messages without crashing the command.
+
+This is the same defensive philosophy this repo applies to request shaping: patch the smallest proven surface and degrade gracefully rather than assuming stability.
+
+If Anthropic changes these endpoints in a breaking way, the command will fail with an explicit error message and the rest of the extension's behavior — provider override, OAuth shaping, `/anthropic-auth:status` — is completely unaffected.
+
 ## Requirements
 
 The Extra Usage tab shows credit and spend data only when Usage credits are enabled on the Anthropic account.
@@ -65,4 +82,3 @@ If a refresh fails after a successful fetch, the last successful snapshot remain
 - `pnpm run lint` passed.
 - LSP diagnostics passed with no findings.
 - Live Pi smoke test passed with local reset times, dynamic quota output, scaled credits, and store billing guidance.
-

--- a/PR.md
+++ b/PR.md
@@ -6,7 +6,7 @@
 
 ## Summary
 
-Pi users can now inspect Anthropic subscription usage, account metadata, and extra-usage credits directly through `/anthropic-usage`.
+Pi users can inspect Anthropic subscription usage, account metadata, and extra-usage credits directly through `/anthropic-usage`.
 
 The command uses Pi's existing Anthropic OAuth credential and leaves the existing provider override and `/anthropic-auth:status` behavior unchanged.
 
@@ -15,11 +15,16 @@ The command uses Pi's existing Anthropic OAuth credential and leaves the existin
 - Added `/anthropic-usage` command registration.
 - Added Bearer-authenticated clients for Anthropic's OAuth usage and profile endpoints.
 - Normalized legacy quota fields and newer `limits[]` entries into dynamic usage windows.
-- Rendered one quota bar for every window returned by Anthropic.
+- Prefer a non-empty `limits[]` response over legacy quota fields to prevent duplicate windows, with legacy fields used as a fallback when `limits[]` is absent or empty.
+- Read structured model and surface scope data from newer `limits[]` entries.
+- Render one quota bar for every normalized window returned by Anthropic.
+- Hide the opaque legacy `nimbus_quill` bucket instead of presenting it as an unexplained additional quota.
 - Added Usage, Account, and Extra Usage dashboard tabs.
+- Added an Extra Usage summary bar to the Usage tab when Anthropic reports usable extra-usage data.
+- Added duplicate suppression when Spend and Extra Usage report the same scaled amounts and compatible currencies.
 - Added Neuralwatt-style bright-blue horizontal rules at the top and bottom of the TUI.
 - Added local-time reset timestamps with timezone abbreviations.
-- Added red styling and explanatory notes for Anthropic-defined additional quotas.
+- Added red styling and explanatory notes for Anthropic-defined additional quotas that are still exposed.
 - Added server-severity-aware quota colors.
 - Added extra-usage credit scaling using `decimal_places`.
 - Added spend scaling using returned minor-unit exponents.
@@ -44,20 +49,22 @@ OAuth access and refresh tokens are never included in command output, logs, or p
 
 ## Undocumented endpoint risk
 
-Both endpoints are undocumented Anthropic OAuth control-plane endpoints. That means field shapes and availability can change without notice.
+Both endpoints are undocumented Anthropic OAuth control-plane endpoints.
+That means field shapes and availability can change without notice.
 
 The implementation is designed to tolerate that:
 
-- All response fields are optional. Missing or unrecognized fields are silently ignored, not treated as zero usage.
-- Unknown `limits[]` window types render with their raw label rather than failing.
-- `decimal_places` and minor-unit exponents are read from the response; the rendering scales with whatever Anthropic returns rather than hard-coding assumptions.
-- If the profile endpoint fails, the Usage tab still renders with a warning — enrichment is best-effort, not required.
+- All response fields are optional.
+- Missing or unrecognized fields are ignored rather than treated as zero usage.
+- Unknown `limits[]` window types render with a useful fallback label rather than failing.
+- `decimal_places` and minor-unit exponents are read from the response instead of hard-coded.
+- If the profile endpoint fails, usage data still renders with a warning because enrichment is best-effort.
 - If a token refresh fails mid-session, the last successful snapshot is shown as stale instead of clearing the display.
-- All HTTP error codes (401, 403, 429, 5xx) produce user-facing messages without crashing the command.
+- HTTP errors including 401, 403, 429, and 5xx responses produce user-facing messages without crashing the command.
 
-This is the same defensive philosophy this repo applies to request shaping: patch the smallest proven surface and degrade gracefully rather than assuming stability.
+This follows the same defensive philosophy used by the request-shaping layer: patch the smallest proven surface and degrade gracefully rather than assuming stability.
 
-If Anthropic changes these endpoints in a breaking way, the command will fail with an explicit error message and the rest of the extension's behavior — provider override, OAuth shaping, `/anthropic-auth:status` — is completely unaffected.
+If Anthropic changes these endpoints in a breaking way, the command will fail with an explicit error message while the rest of the extension — provider override, OAuth shaping, and `/anthropic-auth:status` — remains unaffected.
 
 ## Requirements
 
@@ -77,8 +84,9 @@ If a refresh fails after a successful fetch, the last successful snapshot remain
 
 ## Validation
 
-- `pnpm test` passed: 88 tests.
-- `pnpm run check` passed.
-- `pnpm run lint` passed.
-- LSP diagnostics passed with no findings.
-- Live Pi smoke test passed with local reset times, dynamic quota output, scaled credits, and store billing guidance.
+- `vitest run` passed: 91 tests across 12 test files.
+- `tsc --noEmit` passed.
+- `eslint .` passed.
+- `biome check .` passes for all changed files, with one pre-existing import-order error remaining in untouched `test/usage-client.test.ts`.
+- `rumdl check PR.md` passed.
+- The local `pnpm` wrapper could not run because its native binary integrity entry is missing from `pnpm-lock.yaml`; equivalent binaries were run directly from `node_modules/.bin`.

--- a/PR.md
+++ b/PR.md
@@ -42,6 +42,12 @@ The implementation does not use Claude web cookies, browser sessions, DOM scrapi
 
 OAuth access and refresh tokens are never included in command output, logs, or persisted snapshots.
 
+## Requirements
+
+The Extra Usage tab shows credit and spend data only when Usage credits are enabled on the Anthropic account.
+When they are off, Anthropic does not return credit or spend fields and the tab displays no data.
+Users can enable Usage credits in the Anthropic Console under Settings → Plans & Billing → Usage credits.
+
 ## Compatibility and failure behavior
 
 The feature is additive and does not replace Pi's built-in Anthropic transport.

--- a/PR.md
+++ b/PR.md
@@ -1,0 +1,62 @@
+# Pull Request Description
+
+## Suggested title
+
+`feat: add Anthropic OAuth usage dashboard`
+
+## Summary
+
+Pi users can now inspect Anthropic subscription usage, account metadata, and extra-usage credits directly through `/anthropic-usage`.
+
+The command uses Pi's existing Anthropic OAuth credential and leaves the existing provider override and `/anthropic-auth:status` behavior unchanged.
+
+## What changed
+
+- Added `/anthropic-usage` command registration.
+- Added Bearer-authenticated clients for Anthropic's OAuth usage and profile endpoints.
+- Normalized legacy quota fields and newer `limits[]` entries into dynamic usage windows.
+- Rendered one quota bar for every window returned by Anthropic.
+- Added Usage, Account, and Extra Usage dashboard tabs.
+- Added Neuralwatt-style bright-blue horizontal rules at the top and bottom of the TUI.
+- Added local-time reset timestamps with timezone abbreviations.
+- Added red styling and explanatory notes for Anthropic-defined additional quotas.
+- Added server-severity-aware quota colors.
+- Added extra-usage credit scaling using `decimal_places`.
+- Added spend scaling using returned minor-unit exponents.
+- Added Apple App Store and Google Play Store guidance for canceled subscriptions.
+- Added a 60-second in-memory cache with stale-snapshot fallback after refresh failures.
+- Added headless, RPC, and TUI output paths.
+- Added token-gated OAuth behavior so API-key authentication cannot query this feature.
+
+## Data source and scope
+
+The Usage tab reads `GET https://api.anthropic.com/api/oauth/usage`.
+
+The Account tab enriches usage data with `GET https://api.anthropic.com/api/oauth/profile`.
+
+Both requests use Pi's stored Anthropic OAuth access token as a Bearer token and send `anthropic-beta: oauth-2025-04-20`.
+
+These are undocumented Anthropic OAuth control-plane endpoints, so response fields are parsed defensively and omitted data is not represented as zero usage.
+
+The implementation does not use Claude web cookies, browser sessions, DOM scraping, Pi's host transport, or the pi-ai API registry.
+
+OAuth access and refresh tokens are never included in command output, logs, or persisted snapshots.
+
+## Compatibility and failure behavior
+
+The feature is additive and does not replace Pi's built-in Anthropic transport.
+
+Missing OAuth credentials, API-key authentication, authorization failures, rate limits, server errors, and malformed responses produce user-facing errors without exposing credentials.
+
+If profile enrichment fails, usage data remains available with a warning.
+
+If a refresh fails after a successful fetch, the last successful snapshot remains visible and is marked stale instead of displaying zero usage.
+
+## Validation
+
+- `pnpm test` passed: 88 tests.
+- `pnpm run check` passed.
+- `pnpm run lint` passed.
+- LSP diagnostics passed with no findings.
+- Live Pi smoke test passed with local reset times, dynamic quota output, scaled credits, and store billing guidance.
+

--- a/Plan.md
+++ b/Plan.md
@@ -1,0 +1,359 @@
+# Plan: Add Anthropic OAuth Usage Dashboard
+
+**Target repository:** `pi-anthropic-auth`
+
+**Status:** Implementation complete.
+
+**Implementation started after the pre-implementation gates passed.**
+
+**Plan location:** `Plan.md` is intentionally at the repository root per user instruction and is not intended to participate in the repository's `docs/plans/` automation.
+
+## Overview
+
+Add an `/anthropic-usage` Pi command that reads usage and account information through Anthropic OAuth endpoints using Pi's existing OAuth credential.
+
+The feature will not use Claude web cookies, browser sessions, DOM scraping, or browser automation.
+
+The feature will preserve the existing provider override and `/anthropic-auth:status` behavior.
+
+## Problem Frame
+
+Pi already stores an Anthropic OAuth access token and uses it for Claude requests.
+
+Users need a clear view of the subscription usage windows and account metadata available through the OAuth control plane.
+
+Anthropic's usage response can expose different quota windows for different accounts.
+
+The UI must therefore render the windows returned in the response instead of assuming a fixed number of bars.
+
+## Requirements
+
+1. Register an `/anthropic-usage` command.
+2. Use the existing Anthropic OAuth credential without exposing access or refresh tokens.
+3. Fetch usage data from `https://api.anthropic.com/api/oauth/usage`.
+4. Fetch account identity from `https://api.anthropic.com/api/oauth/profile`.
+5. Normalize legacy usage fields and newer self-describing `limits[]` entries into one internal window model.
+6. Render one usage bar for every normalized quota window present in the response.
+7. Render five-hour and seven-day windows using clear labels when those fields are present.
+8. Render model-scoped windows such as Sonnet and Opus using the model or scope supplied by Anthropic.
+9. Render additional scoped windows such as Cowork or Routines when Anthropic supplies them.
+10. Render extra-usage credit information when the usage response supplies it.
+11. Show account identity and subscription metadata returned by the OAuth profile or usage response.
+12. Preserve the last successful snapshot during transient fetch failures and mark it stale instead of displaying zero usage.
+13. Cache successful usage data and avoid aggressive repeated polling that could trigger rate limits.
+14. Support TUI, headless print, and RPC contexts using the repository's existing command-handler conventions.
+
+## Planned User Interface
+
+The command will open a dashboard with three tabs.
+
+### Usage tab
+
+The Usage tab will contain one bar per usage window returned by Anthropic.
+
+Each bar will show a label, used percentage, and reset time when available.
+
+The number of bars will be dynamic.
+
+An account with two returned windows will show two bars.
+
+An account with six returned windows will show six bars.
+
+Missing windows will be omitted rather than displayed as zero.
+
+### Account tab
+
+The Account tab will show email, account UUID, organization name, organization UUID, subscription type, rate-limit tier, subscription status, and last update time when those values are available.
+
+### Extra Usage tab
+
+The Extra Usage tab will show enabled state, used credits, monthly limit, remaining credits, utilization percentage, currency, and disabled reason when those values are available.
+
+## Data Sources
+
+### OAuth usage endpoint
+
+Use `GET https://api.anthropic.com/api/oauth/usage` with the OAuth access token as a Bearer token.
+
+Send the Anthropic OAuth beta header required by the endpoint.
+
+Treat the endpoint as an undocumented external contract whose response shape may evolve.
+
+The parser will accept both legacy named fields and newer `limits[]` entries.
+
+Expected usage data includes five-hour, seven-day, model-scoped, and other scoped quota windows with utilization and reset timestamps.
+
+Expected extra-usage data includes enabled state, used credits, monthly limit, utilization, currency, and disabled reason.
+
+### OAuth profile endpoint
+
+Use `GET https://api.anthropic.com/api/oauth/profile` with the OAuth access token as a Bearer token.
+
+Use the profile response for account and organization identity fields.
+
+### Local Pi credential
+
+Resolve the Anthropic credential through Pi's supported provider-auth or API-key mechanism.
+
+Do not read, print, duplicate, or persist raw access or refresh tokens outside Pi's existing credential storage.
+
+## Data Model Direction
+
+Normalize every quota entry into a window containing an identifier, display label, optional model or scope, utilization percentage, optional reset timestamp, and source field.
+
+Normalize legacy fields such as `five_hour`, `seven_day`, `seven_day_sonnet`, `seven_day_opus`, `seven_day_cowork`, and `seven_day_routines` into the same window list.
+
+Preserve unknown entries from `limits[]` instead of dropping them so new Anthropic windows can appear without a code change.
+
+Represent missing values as absent or null rather than inventing zeroes.
+
+Represent the last successful response separately from the current fetch error so stale data remains distinguishable from live data.
+
+## Scope Boundaries
+
+- Do not access Claude web cookies or `claude.ai` browser-session endpoints.
+- Do not implement prepaid-credit, auto-reload, payment-method, or browser billing integrations.
+- Do not modify Pi core or replace Pi's built-in Anthropic transport.
+- Do not change API-key Anthropic behavior.
+- Do not add background polling.
+- Do not log OAuth tokens or full authorization headers.
+- Do not infer missing quotas from plan names or display missing quotas as zero.
+- Do not promise a fixed number of usage bars.
+
+## Key Technical Decisions
+
+- **Use a dedicated usage client:** Keep usage requests separate from the Anthropic message transport because the usage endpoint uses a different request shape.
+- **Use OAuth-only authentication:** Reuse Pi's resolved Anthropic OAuth credential and reject non-OAuth credentials with a clear user-facing message.
+- **Normalize dynamic windows:** Store quota windows in a list so legacy and future response formats share one renderer.
+- **Render dynamically:** The UI creates bars from normalized windows and does not hardcode a quota count.
+- **Cache conservatively:** Cache successful snapshots for a bounded interval and reuse stale data after fetch failures.
+- **Keep enrichment best-effort:** Profile and optional metadata failures should not discard valid usage data.
+- **Keep output token-safe:** Reports and errors must contain endpoint status and field-level failure information without credential values.
+
+## Pre-Implementation Gates
+
+These gates must be resolved before implementation units begin because they can change the architecture and user interface.
+
+### G1. Verify an out-of-band OAuth credential seam
+
+Confirm from the installed Pi extension API and runtime behavior whether an extension command can resolve the stored Anthropic OAuth credential outside a `streamSimple` request.
+
+The plan must use a supported public seam such as provider-auth resolution or API-key resolution and must not depend on private Pi internals.
+
+If no supported seam exists, stop and revise U2 before implementing the usage client.
+
+The fallback must either descope direct usage fetching or define an explicitly supported credential handoff rather than scraping Pi's credential files.
+
+### G2. Verify interactive custom TUI support
+
+Confirm from the installed Pi extension API and runtime behavior whether a command can open a stateful custom component with tab selection and rerendering.
+
+If supported, retain the three-tab dashboard in U4.
+
+If unsupported, replace the tabbed dashboard with a flat scrollable report or separate command views while preserving the same normalized data model.
+
+Do not implement an unsupported tab component based only on assumptions.
+
+### G3. Verify the OAuth endpoint contract
+
+Capture or otherwise validate the current usage request headers, beta header, status behavior, and representative response shape before U2 is considered ready.
+
+Record whether the endpoint accepts Pi's OAuth credential and whether profile enrichment succeeds with the same credential.
+
+If the endpoint rejects the request because of header, beta, scope, or client restrictions, revise the client design before proceeding.
+
+### Gate Results
+
+- **G1 passed:** Pi 0.84.0 exposes `ctx.modelRegistry.getProviderAuth("anthropic")`, and the live runtime resolved an OAuth credential without a model request.
+- **G2 passed:** Pi 0.84.0 exposes `ctx.ui.custom()` with a stateful component factory, keyboard input, rerender support, and a completion callback.
+- **G3 passed:** The live OAuth credential received HTTP 200 from both usage and profile endpoints using Bearer authentication and the `oauth-2025-04-20` beta header.
+- **Observed usage keys:** `five_hour`, `seven_day`, `seven_day_cowork`, `seven_day_oauth_apps`, `seven_day_omelette`, `seven_day_opus`, `seven_day_sonnet`, `limits`, `extra_usage`, and provider-supplied metadata fields.
+- **Observed profile keys:** `account`, `application`, `enabled_plugins`, and `organization`.
+
+## Implementation Units
+
+- [x] U1. **Define usage and account response models**
+
+**Goal:** Define internal types for normalized quota windows, account metadata, extra usage, snapshots, freshness, and errors.
+
+**Dependencies:** Pre-implementation gates G1, G2, and G3.
+
+**Files:**
+
+- Create: `src/usage-types.ts`
+- Test: `test/usage-types.test.ts`
+
+**Approach:** Separate transport response representations from normalized UI data so Anthropic schema drift does not leak into rendering code.
+
+**Patterns to follow:** Use the small value-object and formatter style established in `src/diagnostics.ts`.
+
+**Test scenarios:**
+
+- Happy path: Normalize legacy five-hour and seven-day entries into two windows with utilization and reset timestamps.
+- Happy path: Normalize model-scoped Sonnet and Opus entries with model labels.
+- Happy path: Preserve unknown `limits[]` entries as normalized windows.
+- Edge case: Preserve null reset timestamps without inventing a reset time.
+- Edge case: Preserve zero utilization as a real value rather than treating it as missing.
+- Error path: Ignore malformed individual optional entries while retaining valid entries.
+
+**Verification:** The normalized model can represent every planned bar and account field without requiring a fixed window count.
+
+- [x] U2. **Implement OAuth usage client**
+
+**Goal:** Fetch and decode usage and profile data through Anthropic's OAuth control-plane endpoints.
+
+**Dependencies:** U1 and pre-implementation gates G1 and G3.
+
+**Files:**
+
+- Create: `src/usage-client.ts`
+- Test: `test/usage-client.test.ts`
+
+**Approach:** Use a dedicated HTTP client with Bearer authentication, required OAuth headers, bounded request context, status validation, and tolerant JSON decoding.
+
+Resolve the credential through the supported seam confirmed by G1.
+
+Do not modify `src/host-transport.ts` unless G1 specifically identifies that file as the supported integration boundary.
+
+If G1 finds no supported seam, pause this unit and revise the plan instead of reading Pi credential files directly.
+
+The client must not reuse the regular Messages API `x-api-key` request path.
+
+Profile enrichment should be best-effort after usage data succeeds.
+
+**Patterns to follow:** Follow the repository's test strategy of mocked `fetch` responses and narrow helper modules.
+
+**Test scenarios:**
+
+- Happy path: Usage request sends Bearer authorization and the required OAuth beta header.
+- Happy path: Usage response containing legacy fields is decoded successfully.
+- Happy path: Usage response containing `limits[]` is decoded successfully.
+- Happy path: Profile response supplies account and organization identity.
+- Error path: Missing OAuth credential returns a safe actionable error without making a request.
+- Error path: HTTP 401, 403, 429, and 5xx responses return classified errors without response secrets.
+- Error path: Malformed JSON returns a parse error without exposing the access token.
+- Integration: A successful usage response remains usable when profile enrichment fails.
+
+**Verification:** Client tests prove exact request authentication, response parsing, and safe failure behavior.
+
+- [x] U3. **Add snapshot cache and freshness handling**
+
+**Goal:** Prevent repeated command invocations from aggressively polling the undocumented usage endpoint and preserve the last successful result during transient failures.
+
+**Dependencies:** U1 and U2.
+
+**Files:**
+
+- Create: `src/usage-cache.ts`
+- Test: `test/usage-cache.test.ts`
+
+**Approach:** Keep an in-memory cache scoped to the extension process, store fetch time and source status, apply a 60-second freshness interval by default, and return stale snapshots with an explicit stale marker after failures.
+
+The 60-second interval is a conservative starting value and may be tuned after controlled endpoint observation without changing the cache contract.
+
+Do not persist OAuth tokens or usage snapshots to a new credential store in this phase.
+
+**Test scenarios:**
+
+- Happy path: A fresh cached snapshot avoids a second network request.
+- Happy path: An expired snapshot triggers a fresh request.
+- Error path: A failed refresh returns the previous snapshot marked stale.
+- Edge case: No previous snapshot returns a clear failure instead of an empty zero-valued dashboard.
+- Edge case: Concurrent requests do not create uncontrolled duplicate fetches.
+
+**Verification:** Repeated command use is rate-limit-conscious and never confuses missing data with zero usage.
+
+- [x] U4. **Implement dashboard rendering and command registration**
+
+**Goal:** Register `/anthropic-usage` and render Usage, Account, and Extra Usage tabs in TUI, headless, and RPC contexts.
+
+**Dependencies:** U1, U2, U3, and pre-implementation gate G2.
+
+**Files:**
+
+- Create: `src/usage-command.ts`
+- Modify: `src/index.ts`
+- Test: `test/usage-command.test.ts`
+- Test: `test/index-registration.test.ts`
+
+**Approach:** Reuse the existing command registration and headless notification conventions.
+
+Use Pi custom UI components only for TUI mode after G2 confirms the required stateful surface.
+
+If G2 fails, render a flat scrollable report or separate command views instead of inventing a tab implementation.
+
+Render one bar for each normalized usage window and use server-provided labels and scopes.
+
+Render stale state, last update time, and fetch errors without replacing valid data with zeroes.
+
+Use compact text output for headless and RPC contexts.
+
+**Test scenarios:**
+
+- Happy path: Command registration exposes `/anthropic-usage`.
+- Happy path: Usage tab renders exactly one bar per normalized window.
+- Happy path: Account tab renders available identity fields.
+- Happy path: Extra Usage tab renders credit usage fields.
+- Edge case: Two returned windows produce two bars.
+- Edge case: Unknown future `limits[]` windows receive readable labels.
+- Error path: Missing OAuth credentials produce a clear message and no dashboard request.
+- Error path: Stale data is labeled stale and retains its previous percentages.
+- Integration: TUI, headless, and RPC paths route output through their appropriate existing interfaces.
+- Regression: Existing `/anthropic-auth:status` registration and provider registration remain unchanged.
+
+**Verification:** `/anthropic-usage` presents live or explicitly stale OAuth usage data without changing existing Anthropic request behavior.
+
+- [x] U5. **Document usage command and operational behavior**
+
+**Goal:** Document the command, dynamic bar behavior, supported fields, caching, and OAuth-only data source.
+
+**Dependencies:** U4.
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `docs/architecture.md` if the new control-plane client changes architecture documentation.
+- Test expectation: none -- documentation-only unit.
+
+**Approach:** Explain that the dashboard renders one bar per quota entry returned by Anthropic and does not assume a fixed count.
+
+Document that usage data is fetched with Pi's OAuth credential and that tokens are never displayed.
+
+**Verification:** Documentation matches the implemented command and does not imply cookie or browser support.
+
+## System-Wide Impact
+
+- **Extension registration:** `src/index.ts` gains one command while preserving the existing provider registration.
+- **Authentication:** The feature consumes Pi's existing Anthropic OAuth credential but does not change login or refresh behavior.
+- **External contract:** Anthropic usage and profile endpoints are undocumented and may change response fields.
+- **UI lifecycle:** TUI rendering must invalidate and rerender when data, tab selection, loading state, or stale state changes.
+- **Error propagation:** Network, authorization, rate-limit, and parse errors become safe user-facing status messages.
+- **Unchanged invariants:** API-key requests, request shaping, built-in model discovery, and `/anthropic-auth:status` remain unchanged.
+
+## Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Usage response schema changes | Tolerant decoding, generic `limits[]` normalization, and fixture-driven tests. |
+| Endpoint rate limiting | In-memory caching, no background polling, and stale snapshot fallback. |
+| OAuth-plane request rejection | Validate headers, beta flag, scopes, status behavior, and a representative response at G3 before committing to U2. |
+| OAuth credential exposure | Bearer headers stay inside the HTTP client and are excluded from logs and reports. |
+| Missing optional fields | Omit individual fields or bars rather than fabricating values. |
+| Profile request failure | Keep valid usage data and mark only account enrichment as unavailable. |
+| TUI complexity | Reuse Pi custom UI primitives and keep headless output independently testable. |
+
+## Deferred Implementation Questions
+
+- Confirm whether account and plan fields are present in the current profile response or require usage-response fallbacks.
+- Confirm whether Anthropic adds new quota scopes that need label-specific presentation after the generic renderer is working.
+- Tune the default 60-second cache interval only if controlled endpoint observation demonstrates a safer value.
+
+## Success Criteria
+
+- `/anthropic-usage` is available after extension load.
+- OAuth usage and profile requests use Bearer authentication without token leakage.
+- Every returned quota window can render as its own bar.
+- The UI does not assume a fixed number of bars.
+- Stale snapshots remain visibly distinct from live data.
+- Existing provider behavior and diagnostics command remain unchanged.
+- Automated tests cover parsing, authentication, caching, rendering, and failure paths.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,25 @@ pi -e npm:@gotgenes/pi-anthropic-auth
 1. Run `/login anthropic` as usual — Pi's native Anthropic login flow is preserved.
 2. Select a Claude Pro/Max model and start chatting. The extension handles compatibility transparently.
 3. API-key behavior is unaffected; the extension's changes apply only to OAuth sessions.
+4. Run `/anthropic-usage` to view OAuth subscription windows, account metadata, and extra-usage credits.
+
+`/anthropic-usage` uses Pi's stored Anthropic OAuth credential and the Anthropic OAuth control-plane endpoints.
+It does not use Claude web cookies, browser sessions, or DOM scraping.
+The Usage view renders one bar for each quota window returned by Anthropic, so the number of bars can vary by account.
+The dashboard also includes Account and Extra Usage views.
+Reset timestamps render as compact local-time values with the timezone abbreviation.
+Opaque server-defined quotas are labeled as additional quotas; `0%` means Anthropic reported no usage for that quota.
+Credit amounts use Anthropic's returned `decimal_places` metadata, while spend values use their returned minor-unit exponent.
+Store-managed canceled subscriptions show Apple App Store or Google Play Store guidance.
+Usage snapshots are cached briefly to avoid aggressive polling, and failed refreshes are shown as stale data rather than zero usage.
+
+### Anthropic data source
+
+The Usage tab reads `GET https://api.anthropic.com/api/oauth/usage`.
+The Account tab enriches it with `GET https://api.anthropic.com/api/oauth/profile`.
+Both requests use Pi's stored Anthropic OAuth credential as a Bearer token and send `anthropic-beta: oauth-2025-04-20`.
+Quota windows come from legacy fields and `limits[]`; credit values use `extra_usage.decimal_places`; spend values use their returned minor-unit `exponent`.
+These are Anthropic OAuth control-plane endpoints, not the Messages API, Claude web cookies, or browser scraping, and they are undocumented endpoints that may change.
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -43,11 +43,15 @@ pi -e npm:@gotgenes/pi-anthropic-auth
 
 `/anthropic-usage` uses Pi's stored Anthropic OAuth credential and the Anthropic OAuth control-plane endpoints.
 It does not use Claude web cookies, browser sessions, or DOM scraping.
-The Usage view renders one bar for each quota window returned by Anthropic, so the number of bars can vary by account.
-The dashboard also includes Account and Extra Usage views.
+The Usage view renders one bar for each normalized quota window returned by Anthropic, so the number of bars can vary by account.
+When Anthropic returns a non-empty `limits[]` array, it takes precedence over legacy quota fields to avoid duplicate windows; legacy fields remain the fallback when `limits[]` is absent or empty.
+The dashboard includes Usage, Account, and Extra Usage views.
+The Usage view also shows an Extra Usage summary bar when Anthropic reports enabled extra usage with a utilization value.
 Reset timestamps render as compact local-time values with the timezone abbreviation.
-Opaque server-defined quotas are labeled as additional quotas; `0%` means Anthropic reported no usage for that quota.
+Unrecognized legacy quota objects are labeled as additional quotas; `0%` means Anthropic reported no usage for that quota.
+The opaque legacy `nimbus_quill` bucket is omitted instead of being shown as an unexplained quota.
 Credit amounts use Anthropic's returned `decimal_places` metadata, while spend values use their returned minor-unit exponent.
+When Spend duplicates Extra Usage after scaling, the duplicate detail is shown only once.
 Store-managed canceled subscriptions show Apple App Store or Google Play Store guidance.
 Usage snapshots are cached briefly to avoid aggressive polling, and failed refreshes are shown as stale data rather than zero usage.
 
@@ -56,8 +60,16 @@ Usage snapshots are cached briefly to avoid aggressive polling, and failed refre
 The Usage tab reads `GET https://api.anthropic.com/api/oauth/usage`.
 The Account tab enriches it with `GET https://api.anthropic.com/api/oauth/profile`.
 Both requests use Pi's stored Anthropic OAuth credential as a Bearer token and send `anthropic-beta: oauth-2025-04-20`.
-Quota windows come from legacy fields and `limits[]`; credit values use `extra_usage.decimal_places`; spend values use their returned minor-unit `exponent`.
+A non-empty `limits[]` array takes precedence over legacy quota fields; legacy fields are used when `limits[]` is absent or empty.
+Structured model and surface scope data from `limits[]` is used to label scoped windows, while unknown limit types receive fallback labels instead of breaking the report.
+Credit values use `extra_usage.decimal_places`; spend values use their returned minor-unit `exponent`.
 These are Anthropic OAuth control-plane endpoints, not the Messages API, Claude web cookies, or browser scraping, and they are undocumented endpoints that may change.
+
+### Extra Usage requirements
+
+The Extra Usage view displays credit and spend data only when Usage credits are enabled on the Anthropic account.
+When Usage credits are disabled, Anthropic does not return those fields and the view displays no data.
+Enable Usage credits in the Anthropic Console under Settings → Plans & Billing → Usage credits.
 
 ## Troubleshooting
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,6 +10,36 @@ Login and refresh are delegated to Pi's built-in `anthropicOAuth` (the extension
 The wrapper is the single shaping point.
 It delegates to Pi's own built-in Anthropic `streamSimple` transport and only injects an `onPayload` step, so it does not reimplement Pi's Anthropic transport.
 
+## OAuth usage control-plane path
+
+The `/anthropic-usage` command is a separate read-only control-plane path and does not modify the Messages API transport.
+
+The command resolves the Anthropic credential through `ctx.modelRegistry.getProviderAuth("anthropic")`, requires an `sk-ant-oat` OAuth token, and sends Bearer-authenticated requests to Anthropic's OAuth usage and profile endpoints.
+
+Usage responses are normalized into dynamic quota windows, extra-usage data, spend metadata, account identity, and freshness warnings.
+
+The Usage TUI renders one bar per returned quota window rather than assuming a fixed number of bars.
+
+Reset timestamps render as compact local-time values with the timezone abbreviation.
+
+Opaque server-defined quota keys are labeled as additional quotas; `0%` means Anthropic reported no usage for that quota.
+
+Extra-usage credit amounts use Anthropic's returned `decimal_places` metadata, and spend amounts use their returned minor-unit exponent.
+
+Store-managed canceled subscriptions include Apple App Store or Google Play Store guidance.
+
+The command caches successful snapshots for 60 seconds, shows the last successful snapshot as stale after refresh failures, and never displays OAuth credentials.
+
+The usage client intentionally does not use `src/host-transport.ts`, the pi-ai API registry, Claude web cookies, or browser-session endpoints.
+
+### Data provenance
+
+The Usage tab reads `GET https://api.anthropic.com/api/oauth/usage`.
+The Account tab enriches it with `GET https://api.anthropic.com/api/oauth/profile`.
+Both requests use Pi's stored Anthropic OAuth credential as a Bearer token and send `anthropic-beta: oauth-2025-04-20`.
+Quota windows come from legacy fields and `limits[]`; credit values use `extra_usage.decimal_places`; spend values use their returned minor-unit `exponent`.
+These are Anthropic OAuth control-plane endpoints, not the Messages API, and they are undocumented endpoints that may change.
+
 ## The problem: a hook-coverage gap
 
 Earlier versions shaped requests in a `before_provider_request` handler.
@@ -187,3 +217,7 @@ Upstream draws the same distinction: `agent-session.ts` branches on `this.agent.
 - `src/request-shaping.ts` — the shaping pipeline applied via `onPayload`.
 - `src/system-prompt-shaping.ts` — anchor-driven preamble sanitizer that preserves tool snippets, guidelines, and appended content.
 - `src/diagnostics.ts` — `ExtensionDiagnostics` value object, `formatDiagnosticsReport`, and `createStatusCommandHandler`; surfaced by the `/anthropic-auth:status` command registered in `src/index.ts`.
+- `src/usage-types.ts` — OAuth usage/profile normalization and dynamic quota-window models.
+- `src/usage-client.ts` — Bearer-authenticated OAuth usage and profile client.
+- `src/usage-cache.ts` — 60-second in-memory snapshot cache and stale fallback.
+- `src/usage-command.ts` — `/anthropic-usage` registration handler, headless report, and TUI dashboard.

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import {
 } from "./diagnostics";
 import { resolveBuiltinAnthropicStreamSimple } from "./host-transport";
 import { createAnthropicOAuthStreamSimple } from "./oauth-transport";
+import { createUsageCommandHandler } from "./usage-command";
 
 export default async function (pi: ExtensionAPI): Promise<void> {
   // Re-register the built-in `anthropic` provider with a thin transport
@@ -96,5 +97,11 @@ export default async function (pi: ExtensionAPI): Promise<void> {
     description:
       "Show pi-anthropic-auth diagnostics: version, loaded module path, and transport status.",
     handler: createStatusCommandHandler(diagnostics),
+  });
+
+  pi.registerCommand("anthropic-usage", {
+    description:
+      "Show Anthropic OAuth usage windows, account details, and extra usage credits.",
+    handler: createUsageCommandHandler(),
   });
 }

--- a/src/usage-cache.ts
+++ b/src/usage-cache.ts
@@ -1,0 +1,83 @@
+import type { UsageSnapshot } from "./usage-types";
+
+export const DEFAULT_USAGE_CACHE_MAX_AGE_MS = 60_000;
+
+export interface UsageCacheOptions {
+  maxAgeMs?: number;
+  now?: () => Date;
+}
+
+export interface CachedUsageSnapshot {
+  snapshot: UsageSnapshot;
+  stale: boolean;
+  error?: string;
+}
+
+export class UsageSnapshotCache {
+  private readonly maxAgeMs: number;
+  private readonly now: () => Date;
+  private readonly snapshots = new Map<string, UsageSnapshot>();
+  private readonly storedAtMs = new Map<string, number>();
+  private readonly refreshPromises = new Map<string, Promise<UsageSnapshot>>();
+
+  constructor(options: UsageCacheOptions = {}) {
+    this.maxAgeMs = options.maxAgeMs ?? DEFAULT_USAGE_CACHE_MAX_AGE_MS;
+    this.now = options.now ?? (() => new Date());
+  }
+
+  async get(
+    fetchSnapshot: () => Promise<UsageSnapshot>,
+    cacheKey = "default",
+  ): Promise<CachedUsageSnapshot> {
+    const cachedSnapshot = this.snapshots.get(cacheKey);
+    if (cachedSnapshot && this.isFresh(cacheKey)) {
+      return { snapshot: cachedSnapshot, stale: false };
+    }
+
+    const refresh =
+      this.refreshPromises.get(cacheKey) ??
+      this.startRefresh(cacheKey, fetchSnapshot);
+    try {
+      return { snapshot: await refresh, stale: false };
+    } catch (error) {
+      const staleSnapshot = this.snapshots.get(cacheKey);
+      if (staleSnapshot) {
+        return {
+          snapshot: staleSnapshot,
+          stale: true,
+          error: errorMessage(error),
+        };
+      }
+      throw error;
+    } finally {
+      if (this.refreshPromises.get(cacheKey) === refresh) {
+        this.refreshPromises.delete(cacheKey);
+      }
+    }
+  }
+
+  private startRefresh(
+    cacheKey: string,
+    fetchSnapshot: () => Promise<UsageSnapshot>,
+  ): Promise<UsageSnapshot> {
+    const refresh = Promise.resolve()
+      .then(fetchSnapshot)
+      .then((snapshot) => {
+        this.snapshots.set(cacheKey, snapshot);
+        this.storedAtMs.set(cacheKey, this.now().getTime());
+        return snapshot;
+      });
+    this.refreshPromises.set(cacheKey, refresh);
+    return refresh;
+  }
+
+  private isFresh(cacheKey: string): boolean {
+    const storedAtMs = this.storedAtMs.get(cacheKey);
+    if (storedAtMs === undefined) return false;
+    return this.now().getTime() - storedAtMs < this.maxAgeMs;
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/src/usage-client.ts
+++ b/src/usage-client.ts
@@ -1,0 +1,173 @@
+import {
+  normalizeProfileResponse,
+  normalizeUsageResponse,
+  type UsageSnapshot,
+} from "./usage-types";
+
+export const USAGE_ENDPOINT = "https://api.anthropic.com/api/oauth/usage";
+export const PROFILE_ENDPOINT = "https://api.anthropic.com/api/oauth/profile";
+export const OAUTH_BETA_HEADER = "oauth-2025-04-20";
+
+export type UsageClientErrorCode =
+  | "missing_token"
+  | "network_error"
+  | "unauthorized"
+  | "forbidden"
+  | "rate_limited"
+  | "server_error"
+  | "http_error"
+  | "invalid_json";
+
+export class UsageClientError extends Error {
+  readonly code: UsageClientErrorCode;
+  readonly status: number | undefined;
+
+  constructor(code: UsageClientErrorCode, message: string, status?: number) {
+    super(message);
+    this.name = "UsageClientError";
+    this.code = code;
+    this.status = status;
+  }
+}
+
+export interface UsageClientOptions {
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+  now?: () => Date;
+}
+
+export async function fetchAnthropicUsage(
+  accessToken: string,
+  options: UsageClientOptions = {},
+): Promise<UsageSnapshot> {
+  const token = accessToken.trim();
+  if (token === "") {
+    throw new UsageClientError(
+      "missing_token",
+      "Anthropic OAuth credentials are not configured.",
+    );
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const headers = createOAuthHeaders(token);
+  const usageResponse = await fetchJson(
+    fetchImpl,
+    USAGE_ENDPOINT,
+    headers,
+    options.signal,
+  );
+  const usage = normalizeUsageResponse(usageResponse);
+  const warnings: string[] = [];
+  let account = {};
+
+  try {
+    const profileResponse = await fetchJson(
+      fetchImpl,
+      PROFILE_ENDPOINT,
+      headers,
+      options.signal,
+    );
+    account = normalizeProfileResponse(profileResponse);
+  } catch (error) {
+    warnings.push(formatProfileWarning(error));
+  }
+
+  return {
+    ...usage,
+    account,
+    fetchedAt: (options.now ?? (() => new Date()))().toISOString(),
+    warnings,
+  };
+}
+
+function createOAuthHeaders(accessToken: string): Headers {
+  return new Headers({
+    Accept: "application/json, text/plain, */*",
+    Authorization: `Bearer ${accessToken}`,
+    "Content-Type": "application/json",
+    "anthropic-beta": OAUTH_BETA_HEADER,
+  });
+}
+
+async function fetchJson(
+  fetchImpl: typeof fetch,
+  endpoint: string,
+  headers: Headers,
+  signal: AbortSignal | undefined,
+): Promise<unknown> {
+  let response: Response;
+  try {
+    response = await fetchImpl(endpoint, { headers, signal });
+  } catch {
+    throw new UsageClientError(
+      "network_error",
+      `Anthropic OAuth request failed for ${endpoint}.`,
+    );
+  }
+
+  if (!response.ok) {
+    throw createHttpError(response.status);
+  }
+
+  let body: string;
+  try {
+    body = await response.text();
+  } catch {
+    throw new UsageClientError(
+      "invalid_json",
+      `Anthropic OAuth response could not be read for ${endpoint}.`,
+    );
+  }
+
+  try {
+    return JSON.parse(body) as unknown;
+  } catch {
+    throw new UsageClientError(
+      "invalid_json",
+      `Anthropic OAuth response was not valid JSON for ${endpoint}.`,
+    );
+  }
+}
+
+function createHttpError(status: number): UsageClientError {
+  if (status === 401) {
+    return new UsageClientError(
+      "unauthorized",
+      "Anthropic OAuth credentials were rejected.",
+      status,
+    );
+  }
+  if (status === 403) {
+    return new UsageClientError(
+      "forbidden",
+      "Anthropic OAuth credentials lack permission for this request.",
+      status,
+    );
+  }
+  if (status === 429) {
+    return new UsageClientError(
+      "rate_limited",
+      "Anthropic OAuth usage requests are rate limited.",
+      status,
+    );
+  }
+  if (status >= 500) {
+    return new UsageClientError(
+      "server_error",
+      "Anthropic OAuth service returned a server error.",
+      status,
+    );
+  }
+  return new UsageClientError(
+    "http_error",
+    `Anthropic OAuth request failed with status ${status}.`,
+    status,
+  );
+}
+
+function formatProfileWarning(error: unknown): string {
+  if (error instanceof UsageClientError && error.status !== undefined) {
+    return `profile request failed with status ${error.status}`;
+  }
+  return "profile request failed";
+}

--- a/src/usage-command.ts
+++ b/src/usage-command.ts
@@ -1,6 +1,6 @@
-import { fetchAnthropicUsage } from "./usage-client";
-import { UsageSnapshotCache } from "./usage-cache";
 import { isAnthropicOAuthToken } from "./oauth-transport";
+import { UsageSnapshotCache } from "./usage-cache";
+import { fetchAnthropicUsage } from "./usage-client";
 import type {
   AccountInfo,
   ExtraUsage,
@@ -120,7 +120,12 @@ export function formatUsageReport(
     );
   }
   if (snapshot.extraUsage) lines.push(...formatExtraUsage(snapshot.extraUsage));
-  if (snapshot.spend) lines.push(...formatSpend(snapshot.spend));
+  if (
+    snapshot.spend &&
+    !isDuplicateSpend(snapshot.extraUsage, snapshot.spend)
+  ) {
+    lines.push(...formatSpend(snapshot.spend));
+  }
   if (snapshot.account.email) {
     lines.push(`  email: ${sanitizeText(snapshot.account.email)}`);
   }
@@ -243,8 +248,6 @@ class UsageDashboard implements UsageUiComponent {
   invalidate(): void {}
 
   private renderUsageTab(): string[] {
-    if (this.snapshot.windows.length === 0)
-      return ["No usage windows returned."];
     const lines = this.snapshot.windows.flatMap((window) => {
       const color = isAdditionalQuota(window)
         ? ANSI_RED
@@ -257,6 +260,10 @@ class UsageDashboard implements UsageUiComponent {
         `  ${usageBar(window.utilizationPercent, color)}${formatReset(window.resetAt)}`,
       ];
     });
+    const extraUsage = renderExtraUsageSummary(this.snapshot.extraUsage);
+    if (extraUsage.length > 0) lines.push(...extraUsage);
+
+    if (lines.length === 0) return ["No usage windows returned."];
     if (hasAdditionalQuota(this.snapshot.windows)) {
       lines.unshift(
         "Note: Additional quota names are Anthropic-defined; 0% means no reported usage.",
@@ -285,7 +292,10 @@ class UsageDashboard implements UsageUiComponent {
     const lines = this.snapshot.extraUsage
       ? formatExtraUsage(this.snapshot.extraUsage).map((line) => line.trim())
       : ["No extra usage data returned."];
-    if (this.snapshot.spend) {
+    if (
+      this.snapshot.spend &&
+      !isDuplicateSpend(this.snapshot.extraUsage, this.snapshot.spend)
+    ) {
       lines.push(
         "",
         ...formatSpend(this.snapshot.spend).map((line) => line.trim()),
@@ -301,6 +311,60 @@ function isAdditionalQuota(window: UsageWindow): boolean {
 
 function hasAdditionalQuota(windows: UsageWindow[]): boolean {
   return windows.some(isAdditionalQuota);
+}
+
+function renderExtraUsageSummary(extraUsage: ExtraUsage | undefined): string[] {
+  if (!extraUsage?.enabled || extraUsage.utilizationPercent === null) {
+    return [];
+  }
+  const color = quotaColor(extraUsage.utilizationPercent);
+  return [
+    colorize(
+      `Extra usage: ${formatPercent(extraUsage.utilizationPercent)}`,
+      color,
+    ),
+    `  ${usageBar(extraUsage.utilizationPercent, color)}`,
+  ];
+}
+
+function isDuplicateSpend(
+  extraUsage: ExtraUsage | undefined,
+  spend: SpendInfo,
+): boolean {
+  const extraUsed = scaledAmount(
+    extraUsage?.usedCredits,
+    extraUsage?.decimalPlaces,
+  );
+  const extraLimit = scaledAmount(
+    extraUsage?.monthlyLimit,
+    extraUsage?.decimalPlaces,
+  );
+  const spendUsed = scaledAmount(spend.usedMinor, spend.exponent);
+  const spendLimit = scaledAmount(spend.limitMinor, spend.exponent);
+
+  return (
+    extraUsed !== undefined &&
+    extraLimit !== undefined &&
+    spendUsed !== undefined &&
+    spendLimit !== undefined &&
+    amountsEqual(extraUsed, spendUsed) &&
+    amountsEqual(extraLimit, spendLimit) &&
+    (extraUsage?.currency === null ||
+      spend.currency === null ||
+      extraUsage?.currency === spend.currency)
+  );
+}
+
+function scaledAmount(
+  amount: number | null | undefined,
+  decimalPlaces: number | null | undefined,
+): number | undefined {
+  if (amount === null || amount === undefined) return undefined;
+  return amount / 10 ** (decimalPlaces ?? 0);
+}
+
+function amountsEqual(left: number, right: number): boolean {
+  return Math.abs(left - right) < 0.000001;
 }
 
 function formatWindow(window: UsageWindow): string {

--- a/src/usage-command.ts
+++ b/src/usage-command.ts
@@ -1,0 +1,522 @@
+import { fetchAnthropicUsage } from "./usage-client";
+import { UsageSnapshotCache } from "./usage-cache";
+import { isAnthropicOAuthToken } from "./oauth-transport";
+import type {
+  AccountInfo,
+  ExtraUsage,
+  SpendInfo,
+  UsageSnapshot,
+  UsageWindow,
+} from "./usage-types";
+
+const ANTHROPIC_PROVIDER = "anthropic";
+const BAR_WIDTH = 24;
+const USAGE_REQUEST_TIMEOUT_MS = 15_000;
+const ANSI_ESCAPE = String.fromCharCode(27);
+const ANSI_RESET = `${ANSI_ESCAPE}[0m`;
+const ANSI_BLUE = `${ANSI_ESCAPE}[94m`;
+const ANSI_CYAN = "\u001b[36m";
+const ANSI_GREEN = "\u001b[32m";
+const ANSI_YELLOW = "\u001b[33m";
+const ANSI_RED = "\u001b[31m";
+
+type UsageNoticeType = "info" | "warning" | "error";
+
+interface ProviderAuthResult {
+  auth: { apiKey?: string };
+}
+
+interface UsageTui {
+  requestRender(): void;
+}
+
+export interface UsageUiComponent {
+  render(width: number): string[];
+  handleInput(data: string): void;
+  invalidate(): void;
+}
+
+export interface UsageCommandContext {
+  mode: "tui" | "rpc" | "json" | "print";
+  hasUI: boolean;
+  modelRegistry: {
+    getProviderAuth(provider: string): Promise<ProviderAuthResult | undefined>;
+  };
+  ui: {
+    notify(message: string, type?: UsageNoticeType): void;
+    custom(
+      factory: (
+        tui: UsageTui,
+        theme: unknown,
+        keybindings: unknown,
+        done: (result: undefined) => void,
+      ) => UsageUiComponent,
+    ): Promise<undefined>;
+  };
+}
+
+export interface UsageCommandOptions {
+  cache?: UsageSnapshotCache;
+  fetchUsage?: typeof fetchAnthropicUsage;
+}
+
+export function createUsageCommandHandler(
+  options: UsageCommandOptions = {},
+): (args: string, ctx: UsageCommandContext) => Promise<void> {
+  const cache = options.cache ?? new UsageSnapshotCache();
+  const fetchUsage = options.fetchUsage ?? fetchAnthropicUsage;
+
+  return async (_args, ctx) => {
+    try {
+      const auth = await ctx.modelRegistry.getProviderAuth(ANTHROPIC_PROVIDER);
+      const accessToken = auth?.auth.apiKey;
+      if (!isAnthropicOAuthToken(accessToken)) {
+        throw new Error("Anthropic OAuth login is required for usage data.");
+      }
+
+      const cached = await cache.get(
+        () =>
+          fetchUsage(accessToken, {
+            signal: AbortSignal.timeout(USAGE_REQUEST_TIMEOUT_MS),
+          }),
+        accessToken,
+      );
+      if (ctx.mode === "tui") {
+        await showUsageDashboard(
+          ctx,
+          cached.snapshot,
+          cached.stale,
+          cached.error,
+        );
+        return;
+      }
+
+      const report = formatUsageReport(
+        cached.snapshot,
+        cached.stale,
+        cached.error,
+      );
+      notifyOrPrint(ctx, report, cached.stale ? "warning" : "info");
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      notifyOrPrint(ctx, `Anthropic usage unavailable: ${message}`, "error");
+    }
+  };
+}
+
+export function formatUsageReport(
+  snapshot: UsageSnapshot,
+  stale = false,
+  error?: string,
+): string {
+  const lines = [
+    "Anthropic usage",
+    `  updated: ${snapshot.fetchedAt}${stale ? " (stale)" : ""}`,
+    ...snapshot.windows.map(formatWindow),
+  ];
+  if (hasAdditionalQuota(snapshot.windows)) {
+    lines.push(
+      "  note: Additional quota names are Anthropic-defined; 0% means no reported usage.",
+    );
+  }
+  if (snapshot.extraUsage) lines.push(...formatExtraUsage(snapshot.extraUsage));
+  if (snapshot.spend) lines.push(...formatSpend(snapshot.spend));
+  if (snapshot.account.email) {
+    lines.push(`  email: ${sanitizeText(snapshot.account.email)}`);
+  }
+  if (snapshot.account.organizationName) {
+    lines.push(
+      `  organization: ${sanitizeText(snapshot.account.organizationName)}`,
+    );
+  }
+  const billingType = formatBillingType(snapshot.account.billingType);
+  if (billingType) lines.push(`  billing: ${billingType}`);
+  if (snapshot.memberDashboardAvailable !== undefined) {
+    lines.push(
+      `  member dashboard: ${String(snapshot.memberDashboardAvailable)}`,
+    );
+  }
+  const subscriptionNote = formatSubscriptionNote(snapshot.account);
+  if (subscriptionNote) lines.push(subscriptionNote);
+  if (snapshot.warnings.length > 0) {
+    lines.push(
+      ...snapshot.warnings.map(
+        (warning) => `  warning: ${sanitizeText(warning)}`,
+      ),
+    );
+  }
+  if (error) lines.push(`  warning: ${sanitizeText(error)}`);
+  return lines.join("\n");
+}
+
+export function createUsageDashboardComponent(
+  snapshot: UsageSnapshot,
+  stale: boolean,
+  error: string | undefined,
+  tui: UsageTui,
+  done: () => void,
+): UsageUiComponent {
+  return new UsageDashboard(snapshot, stale, error, tui, done);
+}
+
+async function showUsageDashboard(
+  ctx: UsageCommandContext,
+  snapshot: UsageSnapshot,
+  stale: boolean,
+  error: string | undefined,
+): Promise<void> {
+  await ctx.ui.custom((tui, _theme, _keybindings, done) =>
+    createUsageDashboardComponent(snapshot, stale, error, tui, () =>
+      done(undefined),
+    ),
+  );
+}
+
+function notifyOrPrint(
+  ctx: UsageCommandContext,
+  message: string,
+  type: UsageNoticeType,
+): void {
+  if (ctx.hasUI) {
+    ctx.ui.notify(message, type);
+  } else {
+    console.log(message);
+  }
+}
+
+class UsageDashboard implements UsageUiComponent {
+  private tab = 0;
+
+  constructor(
+    private readonly snapshot: UsageSnapshot,
+    private readonly stale: boolean,
+    private readonly error: string | undefined,
+    private readonly tui: UsageTui,
+    private readonly done: () => void,
+  ) {}
+
+  render(width: number): string[] {
+    const title = `${colorize("Anthropic usage", ANSI_CYAN)}  ${colorize(
+      `[${this.stale ? "stale" : "live"}]`,
+      this.stale ? ANSI_YELLOW : ANSI_GREEN,
+    )}`;
+    const tabs = ["Usage", "Account", "Extra Usage"]
+      .map((label, index) => {
+        const tab = index === this.tab ? `[${label}]` : ` ${label} `;
+        return index === this.tab ? colorize(tab, ANSI_CYAN) : tab;
+      })
+      .join("  ");
+    const lines = [blueRule(width), "", title, tabs, ""];
+    if (this.tab === 0) lines.push(...this.renderUsageTab());
+    if (this.tab === 1) lines.push(...this.renderAccountTab());
+    if (this.tab === 2) lines.push(...this.renderExtraUsageTab());
+    if (this.error) lines.push("", `Warning: ${sanitizeText(this.error)}`);
+    lines.push(
+      "",
+      "1 Usage  2 Account  3 Extra Usage  Tab switch  Esc/q close",
+      blueRule(width),
+    );
+    return lines.map((line) => truncateLine(line, width));
+  }
+
+  handleInput(data: string): void {
+    if (data === "\u001b" || data === "q" || data === "Q") {
+      this.done();
+      return;
+    }
+    if (data === "1" || data === "2" || data === "3") {
+      this.tab = Number(data) - 1;
+      this.tui.requestRender();
+      return;
+    }
+    if (data === "\t" || data === "\u001b[C") {
+      this.tab = (this.tab + 1) % 3;
+      this.tui.requestRender();
+      return;
+    }
+    if (data === "\u001b[D") {
+      this.tab = (this.tab + 2) % 3;
+      this.tui.requestRender();
+    }
+  }
+
+  invalidate(): void {}
+
+  private renderUsageTab(): string[] {
+    if (this.snapshot.windows.length === 0)
+      return ["No usage windows returned."];
+    const lines = this.snapshot.windows.flatMap((window) => {
+      const color = isAdditionalQuota(window)
+        ? ANSI_RED
+        : quotaColor(window.utilizationPercent, window.severity);
+      return [
+        colorize(
+          `${sanitizeText(window.label)}: ${formatPercent(window.utilizationPercent)}`,
+          color,
+        ),
+        `  ${usageBar(window.utilizationPercent, color)}${formatReset(window.resetAt)}`,
+      ];
+    });
+    if (hasAdditionalQuota(this.snapshot.windows)) {
+      lines.unshift(
+        "Note: Additional quota names are Anthropic-defined; 0% means no reported usage.",
+        "",
+      );
+    }
+    return lines;
+  }
+
+  private renderAccountTab(): string[] {
+    const lines = [
+      `  last updated: ${sanitizeText(this.snapshot.fetchedAt)}`,
+      ...formatAccount(this.snapshot.account),
+    ];
+    if (this.snapshot.memberDashboardAvailable !== undefined) {
+      lines.push(
+        `  member dashboard: ${String(this.snapshot.memberDashboardAvailable)}`,
+      );
+    }
+    const subscriptionNote = formatSubscriptionNote(this.snapshot.account);
+    if (subscriptionNote) lines.push(subscriptionNote);
+    return lines;
+  }
+
+  private renderExtraUsageTab(): string[] {
+    const lines = this.snapshot.extraUsage
+      ? formatExtraUsage(this.snapshot.extraUsage).map((line) => line.trim())
+      : ["No extra usage data returned."];
+    if (this.snapshot.spend) {
+      lines.push(
+        "",
+        ...formatSpend(this.snapshot.spend).map((line) => line.trim()),
+      );
+    }
+    return lines;
+  }
+}
+
+function isAdditionalQuota(window: UsageWindow): boolean {
+  return window.label.startsWith("Additional quota (");
+}
+
+function hasAdditionalQuota(windows: UsageWindow[]): boolean {
+  return windows.some(isAdditionalQuota);
+}
+
+function formatWindow(window: UsageWindow): string {
+  return `  ${sanitizeText(window.label)}: ${formatPercent(window.utilizationPercent)}${formatReset(window.resetAt)}`;
+}
+
+function formatAccount(account: AccountInfo): string[] {
+  const fields: Array<[string, string | boolean | undefined]> = [
+    ["email", account.email],
+    ["account", account.accountUuid],
+    ["organization", account.organizationName],
+    ["organization id", account.organizationUuid],
+    ["rate-limit tier", account.rateLimitTier],
+    ["subscription", account.subscriptionStatus],
+    ["billing", formatBillingType(account.billingType)],
+    ["Claude Max", account.hasClaudeMax],
+    ["Claude Pro", account.hasClaudePro],
+  ];
+  const lines = fields
+    .filter(([, value]) => value !== undefined)
+    .map(([label, value]) => `  ${label}: ${sanitizeText(String(value))}`);
+  return lines.length > 0 ? lines : ["  No account data returned."];
+}
+
+function formatBillingType(
+  billingType: string | undefined,
+): string | undefined {
+  if (billingType === undefined) return undefined;
+  if (billingType === "apple_subscription") return "Apple App Store";
+  if (billingType === "google_subscription") return "Google Play Store";
+  return sanitizeText(billingType.replaceAll("_", " "));
+}
+
+function formatSubscriptionNote(account: AccountInfo): string | undefined {
+  if (account.subscriptionStatus !== "canceled") return undefined;
+  const billingSource = formatBillingType(account.billingType);
+  if (
+    billingSource !== "Apple App Store" &&
+    billingSource !== "Google Play Store"
+  ) {
+    return "  note: Subscription is marked canceled; check the billing provider for renewal status.";
+  }
+  return `  note: Subscription billing is managed through ${billingSource}; check that store for renewal status.`;
+}
+
+function formatExtraUsage(extraUsage: ExtraUsage): string[] {
+  const remainingCredits =
+    extraUsage.monthlyLimit !== null && extraUsage.usedCredits !== null
+      ? Math.max(0, extraUsage.monthlyLimit - extraUsage.usedCredits)
+      : null;
+  return [
+    `  enabled: ${String(extraUsage.enabled)}`,
+    `  credits used: ${formatCreditAmount(
+      extraUsage.usedCredits,
+      extraUsage.currency,
+      extraUsage.decimalPlaces,
+    )}`,
+    `  monthly limit: ${formatCreditAmount(
+      extraUsage.monthlyLimit,
+      extraUsage.currency,
+      extraUsage.decimalPlaces,
+    )}`,
+    `  remaining credits: ${formatCreditAmount(
+      remainingCredits,
+      extraUsage.currency,
+      extraUsage.decimalPlaces,
+    )}`,
+    `  utilization: ${formatNullablePercent(extraUsage.utilizationPercent)}`,
+    `  currency: ${sanitizeText(extraUsage.currency ?? "unknown")}`,
+    `  disabled reason: ${sanitizeText(extraUsage.disabledReason ?? "n/a")}`,
+  ];
+}
+
+function formatSpend(spend: SpendInfo): string[] {
+  return [
+    `  spend enabled: ${formatNullableBoolean(spend.enabled)}`,
+    `  spent: ${formatMinorAmount(spend.usedMinor, spend.currency, spend.exponent)}`,
+    `  spend limit: ${formatMinorAmount(spend.limitMinor, spend.currency, spend.exponent)}`,
+    `  spend utilization: ${formatNullablePercent(spend.utilizationPercent)}`,
+    `  can purchase credits: ${formatNullableBoolean(spend.canPurchaseCredits)}`,
+    `  spend disabled reason: ${sanitizeText(spend.disabledReason ?? "n/a")}`,
+  ];
+}
+
+function usageBar(percent: number, color = quotaColor(percent)): string {
+  const ratio = Math.max(0, Math.min(100, percent)) / 100;
+  const filled = Math.round(ratio * BAR_WIDTH);
+  const bar = `[${"█".repeat(filled)}${"░".repeat(BAR_WIDTH - filled)}] `;
+  return colorize(bar, color);
+}
+
+function quotaColor(percent: number, severity?: string): string {
+  const normalizedSeverity = severity?.toLowerCase();
+  if (normalizedSeverity === "critical" || normalizedSeverity === "error") {
+    return ANSI_RED;
+  }
+  if (normalizedSeverity === "warning") return ANSI_YELLOW;
+  if (percent >= 80) return ANSI_RED;
+  if (percent >= 50) return ANSI_YELLOW;
+  return ANSI_GREEN;
+}
+
+function colorize(value: string, color: string): string {
+  return `${color}${value}${ANSI_RESET}`;
+}
+
+function blueRule(width: number): string {
+  return width > 0 ? colorize("─".repeat(width), ANSI_BLUE) : "";
+}
+
+function formatPercent(percent: number): string {
+  return `${trimNumber(percent)}%`;
+}
+
+function formatNullablePercent(percent: number | null): string {
+  return percent === null ? "unknown" : formatPercent(percent);
+}
+
+function formatNullableBoolean(value: boolean | null): string {
+  return value === null ? "unknown" : String(value);
+}
+
+function formatReset(resetAt: string | null): string {
+  if (resetAt === null) return "";
+  const date = new Date(resetAt);
+  if (Number.isNaN(date.getTime())) return `, resets ${sanitizeText(resetAt)}`;
+
+  const parts = Object.fromEntries(
+    new Intl.DateTimeFormat("en-CA", {
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      hourCycle: "h23",
+      timeZoneName: "short",
+    })
+      .formatToParts(date)
+      .map((part) => [part.type, part.value]),
+  );
+  return `, resets ${parts.year}-${parts.month}-${parts.day} ${parts.hour}:${parts.minute} ${parts.timeZoneName}`;
+}
+
+function formatAmount(
+  amount: number | null,
+  currency: string | null,
+  fractionDigits = 1,
+): string {
+  return amount === null
+    ? "unknown"
+    : `${trimNumber(amount, fractionDigits)} ${sanitizeText(currency ?? "credits")}`;
+}
+
+function formatCreditAmount(
+  amount: number | null,
+  currency: string | null,
+  decimalPlaces: number | null,
+): string {
+  if (amount === null) return "unknown";
+  const scale = decimalPlaces ?? 0;
+  return formatAmount(amount / 10 ** scale, currency, scale);
+}
+
+function formatMinorAmount(
+  amountMinor: number | null,
+  currency: string | null,
+  exponent: number | null,
+): string {
+  if (amountMinor === null) return "unknown";
+  if (exponent === null) {
+    return `${trimNumber(amountMinor)} minor ${sanitizeText(currency ?? "units")}`;
+  }
+  return formatAmount(amountMinor / 10 ** exponent, currency, exponent);
+}
+
+function trimNumber(value: number, fractionDigits = 1): string {
+  if (Number.isInteger(value)) return String(value);
+  const digits = Math.max(0, Math.min(6, fractionDigits));
+  return value
+    .toFixed(digits)
+    .replace(/\.0+$/, "")
+    .replace(/(\.\d*?)0+$/, "$1");
+}
+
+function sanitizeText(value: string): string {
+  let sanitized = "";
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (code > 31 && code !== 127) sanitized += character;
+  }
+  return sanitized;
+}
+
+function truncateLine(value: string, width: number): string {
+  if (width <= 0) return "";
+  const ansiPattern = new RegExp(`${ANSI_ESCAPE}\\[[0-9;]*m`, "g");
+  const ansiPrefixPattern = new RegExp(`^${ANSI_ESCAPE}\\[[0-9;]*m`);
+  if (value.replace(ansiPattern, "").length <= width) return value;
+
+  let output = "";
+  let visibleLength = 0;
+  let index = 0;
+  while (index < value.length && visibleLength < width - 1) {
+    const sgrMatch = ansiPrefixPattern.exec(value.slice(index));
+    if (sgrMatch) {
+      output += sgrMatch[0];
+      index += sgrMatch[0].length;
+      continue;
+    }
+    const codePoint = value.codePointAt(index);
+    if (codePoint === undefined) break;
+    const character = String.fromCodePoint(codePoint);
+    output += character;
+    index += character.length;
+    visibleLength += 1;
+  }
+
+  return `${output}…${value.includes(ANSI_ESCAPE) ? ANSI_RESET : ""}`;
+}

--- a/src/usage-types.ts
+++ b/src/usage-types.ts
@@ -1,0 +1,309 @@
+export interface UsageWindow {
+  id: string;
+  label: string;
+  utilizationPercent: number;
+  resetAt: string | null;
+  source: string;
+  model?: string;
+  scope?: string;
+  severity?: string;
+  isActive?: boolean;
+}
+
+export interface ExtraUsage {
+  enabled: boolean;
+  monthlyLimit: number | null;
+  usedCredits: number | null;
+  utilizationPercent: number | null;
+  currency: string | null;
+  decimalPlaces: number | null;
+  disabledReason: string | null;
+  userDisabled: boolean | null;
+  spendLimitReached: boolean | null;
+  creditsEverEnabled: boolean | null;
+}
+
+export interface SpendInfo {
+  usedMinor: number | null;
+  limitMinor: number | null;
+  currency: string | null;
+  exponent: number | null;
+  utilizationPercent: number | null;
+  enabled: boolean | null;
+  disabledReason: string | null;
+  canPurchaseCredits: boolean | null;
+  canToggle: boolean | null;
+  disclaimer: string | null;
+}
+
+export interface NormalizedUsageData {
+  windows: UsageWindow[];
+  extraUsage?: ExtraUsage;
+  spend?: SpendInfo;
+  memberDashboardAvailable?: boolean;
+}
+
+export interface UsageSnapshot extends NormalizedUsageData {
+  fetchedAt: string;
+  account: AccountInfo;
+  warnings: string[];
+}
+
+export interface AccountInfo {
+  accountUuid?: string;
+  fullName?: string;
+  displayName?: string;
+  email?: string;
+  hasClaudeMax?: boolean;
+  hasClaudePro?: boolean;
+  createdAt?: string;
+  organizationUuid?: string;
+  organizationName?: string;
+  organizationType?: string;
+  billingType?: string;
+  rateLimitTier?: string;
+  seatTier?: string | null;
+  hasExtraUsageEnabled?: boolean;
+  subscriptionStatus?: string;
+}
+
+const LEGACY_WINDOW_LABELS: Record<string, { label: string; model?: string }> =
+  {
+    five_hour: { label: "5-hour session" },
+    seven_day: { label: "7-day all models" },
+    seven_day_cowork: { label: "Cowork weekly", model: "cowork" },
+    seven_day_oauth_apps: { label: "OAuth apps weekly", model: "oauth-apps" },
+    seven_day_omelette: { label: "Omelette weekly", model: "omelette" },
+    seven_day_opus: { label: "Opus weekly", model: "opus" },
+    seven_day_routines: { label: "Routines weekly", model: "routines" },
+    seven_day_sonnet: { label: "Sonnet weekly", model: "sonnet" },
+  };
+
+const USAGE_METADATA_KEYS = new Set([
+  "extra_usage",
+  "limits",
+  "member_dashboard_available",
+  "spend",
+]);
+
+export function normalizeUsageResponse(input: unknown): NormalizedUsageData {
+  const response = asRecord(input);
+  if (!response) return { windows: [] };
+
+  const windows: UsageWindow[] = [];
+  const knownKeys = new Set<string>();
+
+  for (const [key, metadata] of Object.entries(LEGACY_WINDOW_LABELS)) {
+    const window = parseQuotaWindow(
+      response[key],
+      key,
+      metadata.label,
+      metadata.model,
+    );
+    if (!window) continue;
+    windows.push(window);
+    knownKeys.add(key);
+  }
+
+  for (const [key, value] of Object.entries(response)) {
+    if (knownKeys.has(key) || USAGE_METADATA_KEYS.has(key)) continue;
+    const window = parseQuotaWindow(
+      value,
+      key,
+      `Additional quota (${humanizeIdentifier(key)})`,
+    );
+    if (window) windows.push(window);
+  }
+
+  const limits = Array.isArray(response.limits) ? response.limits : [];
+  for (const [index, value] of limits.entries()) {
+    const limit = asRecord(value);
+    const percent = asNumber(limit?.percent);
+    if (!limit || percent === undefined) continue;
+    const group = asString(limit.group);
+    const kind = asString(limit.kind);
+    const scope = asString(limit.scope);
+    const resetAt = asNullableString(limit.resets_at);
+    const severity = asString(limit.severity);
+    const isActive = asBoolean(limit.is_active);
+    const label = group ?? kind ?? `Additional quota (Limit ${index + 1})`;
+    windows.push({
+      id: `limits:${index}`,
+      label,
+      utilizationPercent: percent,
+      resetAt,
+      source: "limits",
+      ...(scope === undefined ? {} : { scope }),
+      ...(severity === undefined ? {} : { severity }),
+      ...(isActive === undefined ? {} : { isActive }),
+    });
+  }
+
+  const result: NormalizedUsageData = { windows };
+  const extraUsage = parseExtraUsage(response.extra_usage);
+  if (extraUsage) result.extraUsage = extraUsage;
+  const spend = parseSpend(response.spend);
+  if (spend) result.spend = spend;
+  const memberDashboardAvailable = asBoolean(
+    response.member_dashboard_available,
+  );
+  if (memberDashboardAvailable !== undefined) {
+    result.memberDashboardAvailable = memberDashboardAvailable;
+  }
+  return result;
+}
+
+export function normalizeProfileResponse(input: unknown): AccountInfo {
+  const response = asRecord(input);
+  if (!response) return {};
+  const account = asRecord(response.account);
+  const organization = asRecord(response.organization);
+  const result: AccountInfo = {};
+
+  setString(result, "accountUuid", account?.uuid);
+  setString(result, "fullName", account?.full_name);
+  setString(result, "displayName", account?.display_name);
+  setString(result, "email", account?.email);
+  setBoolean(result, "hasClaudeMax", account?.has_claude_max);
+  setBoolean(result, "hasClaudePro", account?.has_claude_pro);
+  setString(result, "createdAt", account?.created_at);
+  setString(result, "organizationUuid", organization?.uuid);
+  setString(result, "organizationName", organization?.name);
+  setString(result, "organizationType", organization?.organization_type);
+  setString(result, "billingType", organization?.billing_type);
+  setString(result, "rateLimitTier", organization?.rate_limit_tier);
+  setNullableString(result, "seatTier", organization?.seat_tier);
+  setBoolean(
+    result,
+    "hasExtraUsageEnabled",
+    organization?.has_extra_usage_enabled,
+  );
+  setString(result, "subscriptionStatus", organization?.subscription_status);
+  return result;
+}
+
+function parseQuotaWindow(
+  input: unknown,
+  id: string,
+  label: string,
+  model?: string,
+): UsageWindow | undefined {
+  const value = asRecord(input);
+  const utilizationPercent = asNumber(value?.utilization);
+  if (!value || utilizationPercent === undefined) return undefined;
+  const resetAt = asNullableString(value.resets_at);
+  return {
+    id,
+    label,
+    utilizationPercent,
+    resetAt,
+    source: id,
+    ...(model === undefined ? {} : { model }),
+  };
+}
+
+function parseExtraUsage(input: unknown): ExtraUsage | undefined {
+  const value = asRecord(input);
+  const enabled = asBoolean(value?.is_enabled);
+  if (!value || enabled === undefined) return undefined;
+  return {
+    enabled,
+    monthlyLimit: asNullableNumber(value.monthly_limit),
+    usedCredits: asNullableNumber(value.used_credits),
+    utilizationPercent: asNullableNumber(value.utilization),
+    currency: asNullableString(value.currency),
+    decimalPlaces: asNullableNumber(value.decimal_places),
+    disabledReason: asNullableString(value.disabled_reason),
+    userDisabled: asNullableBoolean(value.user_disabled),
+    spendLimitReached: asNullableBoolean(value.spend_limit_reached),
+    creditsEverEnabled: asNullableBoolean(value.credits_ever_enabled),
+  };
+}
+
+function parseSpend(input: unknown): SpendInfo | undefined {
+  const value = asRecord(input);
+  if (!value) return undefined;
+  const used = asRecord(value.used);
+  const limit = asRecord(value.limit);
+  return {
+    usedMinor: asNullableNumber(used?.amount_minor),
+    limitMinor: asNullableNumber(limit?.amount_minor),
+    currency: asNullableString(used?.currency ?? limit?.currency),
+    exponent: asNullableNumber(used?.exponent ?? limit?.exponent),
+    utilizationPercent: asNullableNumber(value.percent),
+    enabled: asNullableBoolean(value.enabled),
+    disabledReason: asNullableString(value.disabled_reason),
+    canPurchaseCredits: asNullableBoolean(value.can_purchase_credits),
+    canToggle: asNullableBoolean(value.can_toggle),
+    disclaimer: asNullableString(value.disclaimer),
+  };
+}
+
+function humanizeIdentifier(value: string): string {
+  return value
+    .replaceAll(/[-_]+/g, " ")
+    .replace(/\boauth\b/gi, "OAuth")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function asNullableString(value: unknown): string | null {
+  return value === null ? null : (asString(value) ?? null);
+}
+
+function asNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value)
+    ? value
+    : undefined;
+}
+
+function asNullableNumber(value: unknown): number | null {
+  return value === null ? null : (asNumber(value) ?? null);
+}
+
+function asBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function asNullableBoolean(value: unknown): boolean | null {
+  return value === null ? null : (asBoolean(value) ?? null);
+}
+
+function setString<T extends keyof AccountInfo>(
+  target: AccountInfo,
+  key: T,
+  value: unknown,
+): void {
+  const stringValue = asString(value);
+  if (stringValue !== undefined) target[key] = stringValue as AccountInfo[T];
+}
+
+function setNullableString<T extends keyof AccountInfo>(
+  target: AccountInfo,
+  key: T,
+  value: unknown,
+): void {
+  if (value === null) {
+    target[key] = null as AccountInfo[T];
+    return;
+  }
+  setString(target, key, value);
+}
+
+function setBoolean<T extends keyof AccountInfo>(
+  target: AccountInfo,
+  key: T,
+  value: unknown,
+): void {
+  const booleanValue = asBoolean(value);
+  if (booleanValue !== undefined) target[key] = booleanValue as AccountInfo[T];
+}

--- a/src/usage-types.ts
+++ b/src/usage-types.ts
@@ -86,58 +86,15 @@ const USAGE_METADATA_KEYS = new Set([
   "spend",
 ]);
 
+const HIDDEN_OPAQUE_QUOTA_KEYS = new Set(["nimbus_quill"]);
+
 export function normalizeUsageResponse(input: unknown): NormalizedUsageData {
   const response = asRecord(input);
   if (!response) return { windows: [] };
 
-  const windows: UsageWindow[] = [];
-  const knownKeys = new Set<string>();
-
-  for (const [key, metadata] of Object.entries(LEGACY_WINDOW_LABELS)) {
-    const window = parseQuotaWindow(
-      response[key],
-      key,
-      metadata.label,
-      metadata.model,
-    );
-    if (!window) continue;
-    windows.push(window);
-    knownKeys.add(key);
-  }
-
-  for (const [key, value] of Object.entries(response)) {
-    if (knownKeys.has(key) || USAGE_METADATA_KEYS.has(key)) continue;
-    const window = parseQuotaWindow(
-      value,
-      key,
-      `Additional quota (${humanizeIdentifier(key)})`,
-    );
-    if (window) windows.push(window);
-  }
-
-  const limits = Array.isArray(response.limits) ? response.limits : [];
-  for (const [index, value] of limits.entries()) {
-    const limit = asRecord(value);
-    const percent = asNumber(limit?.percent);
-    if (!limit || percent === undefined) continue;
-    const group = asString(limit.group);
-    const kind = asString(limit.kind);
-    const scope = asString(limit.scope);
-    const resetAt = asNullableString(limit.resets_at);
-    const severity = asString(limit.severity);
-    const isActive = asBoolean(limit.is_active);
-    const label = group ?? kind ?? `Additional quota (Limit ${index + 1})`;
-    windows.push({
-      id: `limits:${index}`,
-      label,
-      utilizationPercent: percent,
-      resetAt,
-      source: "limits",
-      ...(scope === undefined ? {} : { scope }),
-      ...(severity === undefined ? {} : { severity }),
-      ...(isActive === undefined ? {} : { isActive }),
-    });
-  }
+  const limitWindows = parseLimitWindows(response.limits);
+  const windows =
+    limitWindows.length > 0 ? limitWindows : parseLegacyWindows(response);
 
   const result: NormalizedUsageData = { windows };
   const extraUsage = parseExtraUsage(response.extra_usage);
@@ -180,6 +137,100 @@ export function normalizeProfileResponse(input: unknown): AccountInfo {
   );
   setString(result, "subscriptionStatus", organization?.subscription_status);
   return result;
+}
+
+function parseLegacyWindows(response: Record<string, unknown>): UsageWindow[] {
+  const windows: UsageWindow[] = [];
+  const knownKeys = new Set<string>();
+
+  for (const [key, metadata] of Object.entries(LEGACY_WINDOW_LABELS)) {
+    const window = parseQuotaWindow(
+      response[key],
+      key,
+      metadata.label,
+      metadata.model,
+    );
+    if (!window) continue;
+    windows.push(window);
+    knownKeys.add(key);
+  }
+
+  for (const [key, value] of Object.entries(response)) {
+    if (
+      knownKeys.has(key) ||
+      USAGE_METADATA_KEYS.has(key) ||
+      HIDDEN_OPAQUE_QUOTA_KEYS.has(key)
+    ) {
+      continue;
+    }
+    const window = parseQuotaWindow(
+      value,
+      key,
+      `Additional quota (${humanizeIdentifier(key)})`,
+    );
+    if (window) windows.push(window);
+  }
+
+  return windows;
+}
+
+function parseLimitWindows(input: unknown): UsageWindow[] {
+  if (!Array.isArray(input)) return [];
+
+  return input.flatMap((value, index) => {
+    const limit = asRecord(value);
+    const percent = asNumber(limit?.percent);
+    if (!limit || percent === undefined) return [];
+
+    const kind = asString(limit.kind);
+    const group = asString(limit.group);
+    const scopedModel = readScopeName(limit.scope);
+    const scope = asString(limit.scope);
+    const resetAt = asNullableString(limit.resets_at);
+    const severity = asString(limit.severity);
+    const isActive = asBoolean(limit.is_active);
+    const label = limitLabel(kind, group, scopedModel, index);
+
+    return [
+      {
+        id: `limits:${index}`,
+        label,
+        utilizationPercent: percent,
+        resetAt,
+        source: "limits",
+        ...(scope === undefined ? {} : { scope }),
+        ...(scopedModel === undefined ? {} : { model: scopedModel }),
+        ...(severity === undefined ? {} : { severity }),
+        ...(isActive === undefined ? {} : { isActive }),
+      },
+    ];
+  });
+}
+
+function limitLabel(
+  kind: string | undefined,
+  group: string | undefined,
+  scopedModel: string | undefined,
+  index: number,
+): string {
+  if (kind === "session" || group === "session") return "5-hour session";
+  if (kind === "weekly_all") return "7-day all models";
+  if (kind === "weekly_scoped" && scopedModel !== undefined) {
+    return `${scopedModel} weekly`;
+  }
+  return group ?? kind ?? `Additional quota (Limit ${index + 1})`;
+}
+
+function readScopeName(input: unknown): string | undefined {
+  const scope = asRecord(input);
+  const model = asRecord(scope?.model);
+  const surface = asRecord(scope?.surface);
+  return (
+    asString(model?.display_name) ??
+    asString(model?.id) ??
+    asString(surface?.display_name) ??
+    asString(surface?.id)
+  );
 }
 
 function parseQuotaWindow(

--- a/test/index-registration.test.ts
+++ b/test/index-registration.test.ts
@@ -18,7 +18,6 @@ import type {
 } from "@earendil-works/pi-coding-agent";
 import type { Mock } from "vitest";
 import { beforeEach, describe, onTestFinished, test, vi } from "vitest";
-import type { StatusCommandContext } from "#src/diagnostics";
 
 const OAUTH_TOKEN = "sk-ant-oat01-example-access-token";
 
@@ -103,7 +102,7 @@ function lazyStubStreamSimple(
 
 type CapturedCommand = {
   description?: string;
-  handler: (args: string, ctx: StatusCommandContext) => Promise<void>;
+  handler: (args: string, ctx: unknown) => Promise<void>;
 };
 
 /**
@@ -338,6 +337,10 @@ describe("index registration: diagnostics command", () => {
     assert.ok(
       commands.has("anthropic-auth:status"),
       "anthropic-auth:status command must be registered",
+    );
+    assert.ok(
+      commands.has("anthropic-usage"),
+      "anthropic-usage command must be registered",
     );
   });
 

--- a/test/usage-cache.test.ts
+++ b/test/usage-cache.test.ts
@@ -1,0 +1,122 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import {
+  DEFAULT_USAGE_CACHE_MAX_AGE_MS,
+  UsageSnapshotCache,
+} from "#src/usage-cache";
+import type { UsageSnapshot } from "#src/usage-types";
+
+const FIRST_TIME = new Date("2026-08-22T20:00:00Z");
+
+function snapshot(fetchedAt = FIRST_TIME.toISOString()): UsageSnapshot {
+  return {
+    windows: [
+      {
+        id: "five_hour",
+        label: "5-hour session",
+        utilizationPercent: 25,
+        resetAt: null,
+        source: "five_hour",
+      },
+    ],
+    account: {},
+    fetchedAt,
+    warnings: [],
+  };
+}
+
+describe("UsageSnapshotCache", () => {
+  test("uses a fresh snapshot without fetching again", async () => {
+    const fetchSnapshot = vi.fn(async () => snapshot());
+    const cache = new UsageSnapshotCache({
+      maxAgeMs: DEFAULT_USAGE_CACHE_MAX_AGE_MS,
+      now: () => FIRST_TIME,
+    });
+
+    await cache.get(fetchSnapshot);
+    const result = await cache.get(fetchSnapshot);
+
+    assert.equal(fetchSnapshot.mock.calls.length, 1);
+    assert.equal(result.stale, false);
+    assert.equal(result.snapshot.windows[0]?.utilizationPercent, 25);
+  });
+
+  test("refreshes an expired snapshot", async () => {
+    let now = FIRST_TIME.getTime();
+    const fetchSnapshot = vi
+      .fn<() => Promise<UsageSnapshot>>()
+      .mockResolvedValueOnce(snapshot())
+      .mockResolvedValueOnce(snapshot(new Date(now + 61_000).toISOString()));
+    const cache = new UsageSnapshotCache({
+      maxAgeMs: 60_000,
+      now: () => new Date(now),
+    });
+
+    await cache.get(fetchSnapshot);
+    now += 61_000;
+    const result = await cache.get(fetchSnapshot);
+
+    assert.equal(fetchSnapshot.mock.calls.length, 2);
+    assert.equal(result.stale, false);
+    assert.equal(result.snapshot.fetchedAt, new Date(now).toISOString());
+  });
+
+  test("returns the last snapshot as stale after refresh failure", async () => {
+    let now = FIRST_TIME.getTime();
+    const fetchSnapshot = vi
+      .fn<() => Promise<UsageSnapshot>>()
+      .mockResolvedValueOnce(snapshot())
+      .mockRejectedValueOnce(new Error("429 from usage endpoint"));
+    const cache = new UsageSnapshotCache({
+      maxAgeMs: 60_000,
+      now: () => new Date(now),
+    });
+
+    await cache.get(fetchSnapshot);
+    now += 61_000;
+    const result = await cache.get(fetchSnapshot);
+
+    assert.equal(result.stale, true);
+    assert.equal(result.snapshot.fetchedAt, FIRST_TIME.toISOString());
+    assert.equal(result.error, "429 from usage endpoint");
+  });
+
+  test("does not return an empty dashboard when the first fetch fails", async () => {
+    const cache = new UsageSnapshotCache({ now: () => FIRST_TIME });
+
+    await assert.rejects(
+      cache.get(async () => {
+        throw new Error("network down");
+      }),
+      /network down/,
+    );
+  });
+
+  test("shares one in-flight refresh between concurrent callers", async () => {
+    const deferred = Promise.withResolvers<UsageSnapshot>();
+    const fetchSnapshot = vi.fn(() => deferred.promise);
+    const cache = new UsageSnapshotCache({ now: () => FIRST_TIME });
+
+    const first = cache.get(fetchSnapshot);
+    const second = cache.get(fetchSnapshot);
+    deferred.resolve(snapshot());
+    await Promise.all([first, second]);
+
+    assert.equal(fetchSnapshot.mock.calls.length, 1);
+  });
+
+  test("keeps snapshots isolated by cache key", async () => {
+    const cache = new UsageSnapshotCache({ now: () => FIRST_TIME });
+    const first = snapshot();
+    const second = snapshot("2026-08-22T21:00:00.000Z");
+
+    await cache.get(async () => first, "account-a");
+    await cache.get(async () => second, "account-b");
+
+    const result = await cache.get(
+      async () => snapshot("unexpected"),
+      "account-a",
+    );
+    assert.equal(result.snapshot.fetchedAt, first.fetchedAt);
+  });
+});

--- a/test/usage-client.test.ts
+++ b/test/usage-client.test.ts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { describe, test, vi } from "vitest";
+import {
+  fetchAnthropicUsage,
+  UsageClientError,
+  USAGE_ENDPOINT,
+} from "#src/usage-client";
+
+const TOKEN = "sk-ant-oat-test-token";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("fetchAnthropicUsage", () => {
+  test("fetches usage and profile with Bearer OAuth authentication", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({
+          five_hour: { utilization: 10, resets_at: null },
+        }),
+      )
+      .mockResolvedValueOnce(
+        jsonResponse({
+          account: { email: "ada@example.com" },
+          organization: { name: "Analytical Engines" },
+        }),
+      );
+
+    const result = await fetchAnthropicUsage(TOKEN, {
+      fetchImpl: fetchMock,
+      now: () => new Date("2026-08-22T20:00:00Z"),
+    });
+
+    assert.equal(fetchMock.mock.calls.length, 2);
+    const [usageUrl, usageInit] = fetchMock.mock.calls[0];
+    assert.equal(usageUrl, USAGE_ENDPOINT);
+    assert.equal(
+      new Headers(usageInit?.headers).get("authorization"),
+      `Bearer ${TOKEN}`,
+    );
+    assert.equal(
+      new Headers(usageInit?.headers).get("anthropic-beta"),
+      "oauth-2025-04-20",
+    );
+    assert.deepEqual(result.account, {
+      email: "ada@example.com",
+      organizationName: "Analytical Engines",
+    });
+    assert.equal(result.windows[0]?.utilizationPercent, 10);
+    assert.equal(result.fetchedAt, "2026-08-22T20:00:00.000Z");
+    assert.deepEqual(result.warnings, []);
+  });
+
+  test("does not make a request when the OAuth token is missing", async () => {
+    const fetchMock = vi.fn<typeof fetch>();
+
+    await assert.rejects(
+      fetchAnthropicUsage("", { fetchImpl: fetchMock }),
+      (error: unknown) => {
+        assert.ok(error instanceof UsageClientError);
+        assert.equal(error.code, "missing_token");
+        return true;
+      },
+    );
+    assert.equal(fetchMock.mock.calls.length, 0);
+  });
+
+  test("keeps usage data when profile enrichment fails", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        jsonResponse({ seven_day: { utilization: 20, resets_at: null } }),
+      )
+      .mockResolvedValueOnce(jsonResponse({ error: "forbidden" }, 403));
+
+    const result = await fetchAnthropicUsage(TOKEN, { fetchImpl: fetchMock });
+
+    assert.equal(result.windows[0]?.utilizationPercent, 20);
+    assert.deepEqual(result.account, {});
+    assert.deepEqual(result.warnings, [
+      "profile request failed with status 403",
+    ]);
+  });
+
+  test("classifies usage authorization failures without including credentials", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ error: "unauthorized" }, 401));
+
+    await assert.rejects(
+      fetchAnthropicUsage(TOKEN, { fetchImpl: fetchMock }),
+      (error: unknown) => {
+        assert.ok(error instanceof UsageClientError);
+        assert.equal(error.code, "unauthorized");
+        assert.equal(error.status, 401);
+        assert.ok(!error.message.includes(TOKEN));
+        return true;
+      },
+    );
+  });
+
+  test.each([
+    [429, "rate_limited"],
+    [503, "server_error"],
+  ] as const)("classifies HTTP %s usage failures", async (status, code) => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(jsonResponse({ error: "failure" }, status));
+
+    await assert.rejects(
+      fetchAnthropicUsage(TOKEN, { fetchImpl: fetchMock }),
+      (error: unknown) => {
+        assert.ok(error instanceof UsageClientError);
+        assert.equal(error.code, code);
+        assert.equal(error.status, status);
+        return true;
+      },
+    );
+  });
+
+  test("classifies malformed usage JSON", async () => {
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(new Response("not json", { status: 200 }));
+
+    await assert.rejects(
+      fetchAnthropicUsage(TOKEN, { fetchImpl: fetchMock }),
+      (error: unknown) => {
+        assert.ok(error instanceof UsageClientError);
+        assert.equal(error.code, "invalid_json");
+        return true;
+      },
+    );
+  });
+});

--- a/test/usage-command.test.ts
+++ b/test/usage-command.test.ts
@@ -1,14 +1,14 @@
 import assert from "node:assert/strict";
 import { beforeEach, describe, test, vi } from "vitest";
+import { UsageSnapshotCache } from "#src/usage-cache";
+import type { fetchAnthropicUsage } from "#src/usage-client";
 import {
   createUsageCommandHandler,
   createUsageDashboardComponent,
   formatUsageReport,
   type UsageCommandContext,
 } from "#src/usage-command";
-import { UsageSnapshotCache } from "#src/usage-cache";
 import type { UsageSnapshot } from "#src/usage-types";
-import { fetchAnthropicUsage } from "#src/usage-client";
 
 const TOKEN = "sk-ant-oat-test-token";
 const SNAPSHOT: UsageSnapshot = {
@@ -164,7 +164,7 @@ describe("createUsageDashboardComponent", () => {
     const usage = component.render(200).join("\n");
 
     assert.match(usage, /Additional quota \(Nimbus Quill\): 0%/);
-    assert.match(usage, /\u001b\[31mAdditional quota/);
+    assert.ok(usage.includes(`${String.fromCharCode(27)}[31mAdditional quota`));
     assert.match(usage, /0% means no reported usage/);
   });
 
@@ -190,8 +190,80 @@ describe("createUsageDashboardComponent", () => {
     );
     assert.match(
       component.render(200).join("\n"),
-      /\u001b\[31mNamed quota: 10%/,
+      new RegExp(`${String.fromCharCode(27)}\\[31mNamed quota: 10%`),
     );
+  });
+
+  test("omits the summary bar when extra usage is unavailable", () => {
+    const component = createUsageDashboardComponent(
+      {
+        ...SNAPSHOT,
+        windows: [],
+        extraUsage: {
+          enabled: false,
+          monthlyLimit: null,
+          usedCredits: null,
+          utilizationPercent: null,
+          currency: null,
+          decimalPlaces: null,
+          disabledReason: null,
+          userDisabled: null,
+          spendLimitReached: null,
+          creditsEverEnabled: null,
+        },
+      },
+      false,
+      undefined,
+      { requestRender: vi.fn() },
+      vi.fn(),
+    );
+
+    const usage = component.render(200).join("\n");
+    assert.match(usage, /No usage windows returned/);
+    assert.doesNotMatch(usage, /Extra usage:/);
+  });
+
+  test("omits duplicate spend details when Extra Usage has same amounts", () => {
+    const snapshot: UsageSnapshot = {
+      ...SNAPSHOT,
+      extraUsage: {
+        enabled: true,
+        monthlyLimit: 5000,
+        usedCredits: 496,
+        utilizationPercent: 9.9,
+        currency: "USD",
+        decimalPlaces: 2,
+        disabledReason: null,
+        userDisabled: false,
+        spendLimitReached: false,
+        creditsEverEnabled: true,
+      },
+      spend: {
+        usedMinor: 496,
+        limitMinor: 5000,
+        currency: "USD",
+        exponent: 2,
+        utilizationPercent: 10,
+        enabled: true,
+        disabledReason: null,
+        canPurchaseCredits: false,
+        canToggle: false,
+        disclaimer: null,
+      },
+    };
+    const component = createUsageDashboardComponent(
+      snapshot,
+      false,
+      undefined,
+      { requestRender: vi.fn() },
+      vi.fn(),
+    );
+
+    component.handleInput("3");
+    const extra = component.render(200).join("\\n");
+    assert.match(extra, /credits used: 4\.96 USD/);
+    assert.doesNotMatch(extra, /spend enabled:/);
+    assert.doesNotMatch(formatUsageReport(snapshot), /spend enabled:/);
   });
 
   test("renders dynamic windows, account fields, extra usage, and tab navigation", () => {
@@ -213,8 +285,9 @@ describe("createUsageDashboardComponent", () => {
     const usage = rendered.join("\n");
     assert.match(usage, /5-hour session/);
     assert.match(usage, /Sonnet weekly/);
+    assert.match(usage, /Extra usage: 25%/);
     assert.match(usage, /\[Usage\]/);
-    assert.match(usage, /\u001b\[36m/);
+    assert.ok(usage.includes(`${String.fromCharCode(27)}[36m`));
 
     component.handleInput("\t");
     const account = component.render(200).join("\n");

--- a/test/usage-command.test.ts
+++ b/test/usage-command.test.ts
@@ -1,0 +1,296 @@
+import assert from "node:assert/strict";
+import { beforeEach, describe, test, vi } from "vitest";
+import {
+  createUsageCommandHandler,
+  createUsageDashboardComponent,
+  formatUsageReport,
+  type UsageCommandContext,
+} from "#src/usage-command";
+import { UsageSnapshotCache } from "#src/usage-cache";
+import type { UsageSnapshot } from "#src/usage-types";
+import { fetchAnthropicUsage } from "#src/usage-client";
+
+const TOKEN = "sk-ant-oat-test-token";
+const SNAPSHOT: UsageSnapshot = {
+  windows: [
+    {
+      id: "five_hour",
+      label: "5-hour session",
+      utilizationPercent: 40,
+      resetAt: "2026-08-22T20:00:00Z",
+      source: "five_hour",
+    },
+    {
+      id: "seven_day_sonnet",
+      label: "Sonnet weekly",
+      utilizationPercent: 20,
+      resetAt: null,
+      source: "seven_day_sonnet",
+      model: "sonnet",
+    },
+  ],
+  extraUsage: {
+    enabled: true,
+    monthlyLimit: 10000,
+    usedCredits: 2500,
+    utilizationPercent: 25,
+    currency: "USD",
+    decimalPlaces: 2,
+    disabledReason: "spend limit reached",
+    userDisabled: false,
+    spendLimitReached: false,
+    creditsEverEnabled: true,
+  },
+  spend: {
+    usedMinor: 1250,
+    limitMinor: 5000,
+    currency: "USD",
+    exponent: 2,
+    utilizationPercent: 25,
+    enabled: true,
+    disabledReason: null,
+    canPurchaseCredits: true,
+    canToggle: true,
+    disclaimer: null,
+  },
+  memberDashboardAvailable: true,
+  account: {
+    email: "ada@example.com",
+    organizationName: "Analytical Engines",
+    subscriptionStatus: "canceled",
+    billingType: "apple_subscription",
+  },
+  fetchedAt: "2026-08-22T19:00:00.000Z",
+  warnings: [],
+};
+
+function context(
+  mode: UsageCommandContext["mode"],
+  authKind: "oauth" | "api_key" | "none" = "oauth",
+) {
+  const custom = vi.fn<UsageCommandContext["ui"]["custom"]>(() =>
+    Promise.resolve(undefined),
+  );
+  return {
+    mode,
+    hasUI: false,
+    modelRegistry: {
+      getProviderAuth: vi.fn(async () => {
+        if (authKind === "none") return undefined;
+        const apiKey = authKind === "oauth" ? TOKEN : "sk-ant-api-key";
+        return { auth: { apiKey } };
+      }),
+    },
+    ui: {
+      notify: vi.fn(),
+      custom,
+    },
+  };
+}
+
+describe("formatUsageReport", () => {
+  test("renders every returned window and extra usage fields", () => {
+    const report = formatUsageReport(SNAPSHOT);
+
+    assert.match(report, /5-hour session: 40%/);
+    assert.match(report, /resets \d{4}-\d{2}-\d{2} \d{2}:\d{2} .+/);
+    assert.doesNotMatch(report, /resets \d{4}-\d{2}-\d{2}T/);
+    assert.match(report, /Sonnet weekly: 20%/);
+    assert.match(report, /credits used: 25 USD/);
+    assert.match(report, /monthly limit: 100 USD/);
+    assert.match(report, /ada@example\.com/);
+    assert.match(report, /billing: Apple App Store/);
+    assert.match(report, /check that store for renewal status/);
+  });
+
+  test("marks stale reports and preserves the refresh error", () => {
+    const report = formatUsageReport(SNAPSHOT, true, "rate limited");
+
+    assert.match(report, /stale/);
+    assert.match(report, /warning: rate limited/);
+  });
+
+  test("preserves an invalid reset timestamp instead of throwing", () => {
+    const report = formatUsageReport({
+      ...SNAPSHOT,
+      windows: [{ ...SNAPSHOT.windows[0], resetAt: "not-a-date" }],
+    });
+    assert.match(report, /resets not-a-date/);
+  });
+
+  test("explains Google Play billing and omits the note for active subscriptions", () => {
+    const googleReport = formatUsageReport({
+      ...SNAPSHOT,
+      account: {
+        ...SNAPSHOT.account,
+        billingType: "google_subscription",
+      },
+    });
+    assert.match(googleReport, /billing: Google Play Store/);
+    assert.match(googleReport, /check that store for renewal status/);
+
+    const activeReport = formatUsageReport({
+      ...SNAPSHOT,
+      account: {
+        ...SNAPSHOT.account,
+        subscriptionStatus: "active",
+      },
+    });
+    assert.doesNotMatch(activeReport, /Subscription billing is managed/);
+  });
+});
+
+describe("createUsageDashboardComponent", () => {
+  test("colors additional quotas red and explains their zero values", () => {
+    const component = createUsageDashboardComponent(
+      {
+        ...SNAPSHOT,
+        windows: [
+          ...SNAPSHOT.windows,
+          {
+            id: "nimbus_quill",
+            label: "Additional quota (Nimbus Quill)",
+            utilizationPercent: 0,
+            resetAt: null,
+            source: "nimbus_quill",
+          },
+        ],
+      },
+      false,
+      undefined,
+      { requestRender: vi.fn() },
+      vi.fn(),
+    );
+    const usage = component.render(200).join("\n");
+
+    assert.match(usage, /Additional quota \(Nimbus Quill\): 0%/);
+    assert.match(usage, /\u001b\[31mAdditional quota/);
+    assert.match(usage, /0% means no reported usage/);
+  });
+
+  test("uses server severity for named quota colors", () => {
+    const component = createUsageDashboardComponent(
+      {
+        ...SNAPSHOT,
+        windows: [
+          {
+            id: "named-warning",
+            label: "Named quota",
+            utilizationPercent: 10,
+            resetAt: null,
+            source: "limits",
+            severity: "critical",
+          },
+        ],
+      },
+      false,
+      undefined,
+      { requestRender: vi.fn() },
+      vi.fn(),
+    );
+    assert.match(
+      component.render(200).join("\n"),
+      /\u001b\[31mNamed quota: 10%/,
+    );
+  });
+
+  test("renders dynamic windows, account fields, extra usage, and tab navigation", () => {
+    const tui = { requestRender: vi.fn() };
+    let closed = false;
+    const component = createUsageDashboardComponent(
+      SNAPSHOT,
+      false,
+      undefined,
+      tui,
+      () => {
+        closed = true;
+      },
+    );
+
+    const rendered = component.render(200);
+    assert.equal(rendered[0], `\u001b[94m${"─".repeat(200)}\u001b[0m`);
+    assert.equal(rendered.at(-1), `\u001b[94m${"─".repeat(200)}\u001b[0m`);
+    const usage = rendered.join("\n");
+    assert.match(usage, /5-hour session/);
+    assert.match(usage, /Sonnet weekly/);
+    assert.match(usage, /\[Usage\]/);
+    assert.match(usage, /\u001b\[36m/);
+
+    component.handleInput("\t");
+    const account = component.render(200).join("\n");
+    assert.match(account, /last updated:/);
+    assert.match(account, /ada@example\.com/);
+    assert.match(account, /member dashboard: true/);
+    assert.match(account, /billing: Apple App Store/);
+    assert.match(account, /check that store for renewal status/);
+
+    component.handleInput("\t");
+    const extra = component.render(200).join("\n");
+    assert.match(extra, /remaining credits: 75 USD/);
+    assert.match(extra, /disabled reason: spend limit reached/);
+    assert.match(extra, /spent: 12.5 USD/);
+
+    component.handleInput("\u001b[D");
+    assert.match(component.render(200).join("\n"), /\[Account\]/);
+    component.handleInput("q");
+    assert.equal(closed, true);
+    assert.equal(tui.requestRender.mock.calls.length, 3);
+  });
+});
+
+describe("createUsageCommandHandler", () => {
+  const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+  beforeEach(() => {
+    consoleSpy.mockClear();
+  });
+
+  test("prints a headless report using the resolved OAuth credential", async () => {
+    const fetchUsage = vi
+      .fn<typeof fetchAnthropicUsage>()
+      .mockResolvedValue(SNAPSHOT);
+    const ctx = context("print");
+    const handler = createUsageCommandHandler({
+      fetchUsage,
+      cache: new UsageSnapshotCache({
+        now: () => new Date("2026-08-22T19:00:00Z"),
+      }),
+    });
+
+    await handler("", ctx);
+
+    assert.equal(fetchUsage.mock.calls.length, 1);
+    assert.equal(consoleSpy.mock.calls.length, 1);
+    assert.match(String(consoleSpy.mock.calls[0]?.[0]), /Anthropic usage/);
+  });
+
+  test("requires an OAuth credential without calling the usage client", async () => {
+    const fetchUsage = vi
+      .fn<typeof fetchAnthropicUsage>()
+      .mockResolvedValue(SNAPSHOT);
+    const ctx = context("print", "api_key");
+    const handler = createUsageCommandHandler({ fetchUsage });
+
+    await handler("", ctx);
+
+    assert.equal(fetchUsage.mock.calls.length, 0);
+    assert.equal(consoleSpy.mock.calls.length, 1);
+    assert.match(
+      String(consoleSpy.mock.calls[0]?.[0]),
+      /OAuth login is required/,
+    );
+  });
+
+  test("uses custom TUI only in TUI mode", async () => {
+    const fetchUsage = vi
+      .fn<typeof fetchAnthropicUsage>()
+      .mockResolvedValue(SNAPSHOT);
+    const ctx = context("tui");
+    const handler = createUsageCommandHandler({ fetchUsage });
+
+    await handler("", ctx);
+
+    assert.equal(ctx.ui.custom.mock.calls.length, 1);
+    assert.equal(consoleSpy.mock.calls.length, 0);
+  });
+});

--- a/test/usage-types.test.ts
+++ b/test/usage-types.test.ts
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { describe, test } from "vitest";
+import {
+  normalizeProfileResponse,
+  normalizeUsageResponse,
+} from "#src/usage-types";
+
+describe("normalizeUsageResponse", () => {
+  test("normalizes legacy quota windows", () => {
+    const result = normalizeUsageResponse({
+      five_hour: { utilization: 12.5, resets_at: "2026-08-22T20:00:00Z" },
+      seven_day: { utilization: 34, resets_at: "2026-08-29T20:00:00Z" },
+      seven_day_sonnet: {
+        utilization: 56,
+        resets_at: "2026-08-29T20:00:00Z",
+      },
+    });
+
+    assert.deepEqual(result.windows, [
+      {
+        id: "five_hour",
+        label: "5-hour session",
+        utilizationPercent: 12.5,
+        resetAt: "2026-08-22T20:00:00Z",
+        source: "five_hour",
+      },
+      {
+        id: "seven_day",
+        label: "7-day all models",
+        utilizationPercent: 34,
+        resetAt: "2026-08-29T20:00:00Z",
+        source: "seven_day",
+      },
+      {
+        id: "seven_day_sonnet",
+        label: "Sonnet weekly",
+        utilizationPercent: 56,
+        resetAt: "2026-08-29T20:00:00Z",
+        source: "seven_day_sonnet",
+        model: "sonnet",
+      },
+    ]);
+  });
+
+  test("preserves generic quota entries and limits", () => {
+    const result = normalizeUsageResponse({
+      nimbus_quill: { utilization: 25, resets_at: null },
+      limits: [
+        {
+          kind: "weekly",
+          group: "Claude Code",
+          percent: 40,
+          severity: "warning",
+          resets_at: "2026-08-29T20:00:00Z",
+          scope: "routines",
+          is_active: true,
+        },
+        { percent: 0, resets_at: null, severity: "normal" },
+      ],
+    });
+
+    assert.deepEqual(result.windows, [
+      {
+        id: "nimbus_quill",
+        label: "Additional quota (Nimbus Quill)",
+        utilizationPercent: 25,
+        resetAt: null,
+        source: "nimbus_quill",
+      },
+      {
+        id: "limits:0",
+        label: "Claude Code",
+        utilizationPercent: 40,
+        resetAt: "2026-08-29T20:00:00Z",
+        source: "limits",
+        scope: "routines",
+        severity: "warning",
+        isActive: true,
+      },
+      {
+        id: "limits:1",
+        label: "Additional quota (Limit 2)",
+        utilizationPercent: 0,
+        resetAt: null,
+        source: "limits",
+        severity: "normal",
+      },
+    ]);
+  });
+
+  test("normalizes extra usage without converting missing values to zero", () => {
+    const result = normalizeUsageResponse({
+      extra_usage: {
+        is_enabled: true,
+        monthly_limit: 100,
+        used_credits: 25,
+        utilization: 25,
+        currency: "USD",
+        decimal_places: 2,
+        disabled_reason: null,
+        user_disabled: false,
+        spend_limit_reached: false,
+        credits_ever_enabled: true,
+      },
+      spend: {
+        used: { amount_minor: 1250, currency: "USD", exponent: 2 },
+        limit: { amount_minor: 5000, currency: "USD", exponent: 2 },
+        percent: 25,
+        enabled: true,
+        disabled_reason: null,
+        can_purchase_credits: true,
+        can_toggle: false,
+        disclaimer: "Usage credits apply after included usage.",
+      },
+      member_dashboard_available: true,
+    });
+
+    assert.deepEqual(result.extraUsage, {
+      enabled: true,
+      monthlyLimit: 100,
+      usedCredits: 25,
+      utilizationPercent: 25,
+      currency: "USD",
+      decimalPlaces: 2,
+      disabledReason: null,
+      userDisabled: false,
+      spendLimitReached: false,
+      creditsEverEnabled: true,
+    });
+    assert.deepEqual(result.spend, {
+      usedMinor: 1250,
+      limitMinor: 5000,
+      currency: "USD",
+      exponent: 2,
+      utilizationPercent: 25,
+      enabled: true,
+      disabledReason: null,
+      canPurchaseCredits: true,
+      canToggle: false,
+      disclaimer: "Usage credits apply after included usage.",
+    });
+    assert.equal(result.memberDashboardAvailable, true);
+  });
+
+  test("preserves zero utilization as a real value", () => {
+    const result = normalizeUsageResponse({
+      five_hour: { utilization: 0, resets_at: null },
+    });
+
+    assert.equal(result.windows[0]?.utilizationPercent, 0);
+  });
+});
+
+describe("normalizeProfileResponse", () => {
+  test("normalizes account and organization identity", () => {
+    const result = normalizeProfileResponse({
+      account: {
+        uuid: "account-1",
+        full_name: "Ada Lovelace",
+        display_name: "Ada",
+        email: "ada@example.com",
+        has_claude_max: true,
+        has_claude_pro: false,
+        created_at: "2026-01-01T00:00:00Z",
+      },
+      organization: {
+        uuid: "org-1",
+        name: "Analytical Engines",
+        organization_type: "claude_ai",
+        billing_type: "subscription",
+        rate_limit_tier: "default_claude_max_5x",
+        seat_tier: null,
+        has_extra_usage_enabled: true,
+        subscription_status: "active",
+      },
+    });
+
+    assert.deepEqual(result, {
+      accountUuid: "account-1",
+      fullName: "Ada Lovelace",
+      displayName: "Ada",
+      email: "ada@example.com",
+      hasClaudeMax: true,
+      hasClaudePro: false,
+      createdAt: "2026-01-01T00:00:00Z",
+      organizationUuid: "org-1",
+      organizationName: "Analytical Engines",
+      organizationType: "claude_ai",
+      billingType: "subscription",
+      rateLimitTier: "default_claude_max_5x",
+      seatTier: null,
+      hasExtraUsageEnabled: true,
+      subscriptionStatus: "active",
+    });
+  });
+
+  test("returns an empty normalized profile for missing optional objects", () => {
+    assert.deepEqual(normalizeProfileResponse({}), {});
+  });
+});

--- a/test/usage-types.test.ts
+++ b/test/usage-types.test.ts
@@ -42,48 +42,65 @@ describe("normalizeUsageResponse", () => {
     ]);
   });
 
-  test("preserves generic quota entries and limits", () => {
+  test("prefers limits and hides opaque Nimbus quota data", () => {
     const result = normalizeUsageResponse({
+      five_hour: { utilization: 12, resets_at: "2026-08-22T20:00:00Z" },
       nimbus_quill: { utilization: 25, resets_at: null },
       limits: [
         {
-          kind: "weekly",
-          group: "Claude Code",
+          kind: "session",
+          group: "session",
           percent: 40,
-          severity: "warning",
-          resets_at: "2026-08-29T20:00:00Z",
-          scope: "routines",
+          resets_at: "2026-08-22T20:00:00Z",
           is_active: true,
         },
-        { percent: 0, resets_at: null, severity: "normal" },
+        {
+          kind: "weekly_scoped",
+          group: "weekly",
+          percent: 0,
+          resets_at: null,
+          scope: { model: { display_name: "Fable" }, surface: null },
+        },
       ],
     });
 
     assert.deepEqual(result.windows, [
       {
-        id: "nimbus_quill",
-        label: "Additional quota (Nimbus Quill)",
-        utilizationPercent: 25,
-        resetAt: null,
-        source: "nimbus_quill",
-      },
-      {
         id: "limits:0",
-        label: "Claude Code",
+        label: "5-hour session",
         utilizationPercent: 40,
-        resetAt: "2026-08-29T20:00:00Z",
+        resetAt: "2026-08-22T20:00:00Z",
         source: "limits",
-        scope: "routines",
-        severity: "warning",
         isActive: true,
       },
       {
         id: "limits:1",
-        label: "Additional quota (Limit 2)",
+        label: "Fable weekly",
         utilizationPercent: 0,
         resetAt: null,
         source: "limits",
-        severity: "normal",
+        model: "Fable",
+      },
+    ]);
+  });
+
+  test("uses legacy windows when limits are absent", () => {
+    const result = normalizeUsageResponse({
+      nimbus_quill: { utilization: 25, resets_at: null },
+      seven_day_sonnet: {
+        utilization: 56,
+        resets_at: "2026-08-29T20:00:00Z",
+      },
+    });
+
+    assert.deepEqual(result.windows, [
+      {
+        id: "seven_day_sonnet",
+        label: "Sonnet weekly",
+        utilizationPercent: 56,
+        resetAt: "2026-08-29T20:00:00Z",
+        source: "seven_day_sonnet",
+        model: "sonnet",
       },
     ]);
   });


### PR DESCRIPTION
# Pull Request Description

## Suggested title

`feat: add Anthropic OAuth usage dashboard`

## Summary

Pi users can inspect Anthropic subscription usage, account metadata, and extra-usage credits directly through `/anthropic-usage`.

The command uses Pi's existing Anthropic OAuth credential and leaves the existing provider override and `/anthropic-auth:status` behavior unchanged.

## What changed

- Added `/anthropic-usage` command registration.
- Added Bearer-authenticated clients for Anthropic's OAuth usage and profile endpoints.
- Normalized legacy quota fields and newer `limits[]` entries into dynamic usage windows.
- Prefer a non-empty `limits[]` response over legacy quota fields to prevent duplicate windows, with legacy fields used as a fallback when `limits[]` is absent or empty.
- Read structured model and surface scope data from newer `limits[]` entries.
- Render one quota bar for every normalized window returned by Anthropic.
- Hide the opaque legacy `nimbus_quill` bucket instead of presenting it as an unexplained additional quota.
- Added Usage, Account, and Extra Usage dashboard tabs.
- Added an Extra Usage summary bar to the Usage tab when Anthropic reports usable extra-usage data.
- Added duplicate suppression when Spend and Extra Usage report the same scaled amounts and compatible currencies.
- Added Neuralwatt-style bright-blue horizontal rules at the top and bottom of the TUI.
- Added local-time reset timestamps with timezone abbreviations.
- Added red styling and explanatory notes for Anthropic-defined additional quotas that are still exposed.
- Added server-severity-aware quota colors.
- Added extra-usage credit scaling using `decimal_places`.
- Added spend scaling using returned minor-unit exponents.
- Added Apple App Store and Google Play Store guidance for canceled subscriptions.
- Added a 60-second in-memory cache with stale-snapshot fallback after refresh failures.
- Added headless, RPC, and TUI output paths.
- Added token-gated OAuth behavior so API-key authentication cannot query this feature.

## Data source and scope

The Usage tab reads `GET https://api.anthropic.com/api/oauth/usage`.

The Account tab enriches usage data with `GET https://api.anthropic.com/api/oauth/profile`.

Both requests use Pi's stored Anthropic OAuth access token as a Bearer token and send `anthropic-beta: oauth-2025-04-20`.

These are undocumented Anthropic OAuth control-plane endpoints, so response fields are parsed defensively and omitted data is not represented as zero usage.

The implementation does not use Claude web cookies, browser sessions, DOM scraping, Pi's host transport, or the pi-ai API registry.

OAuth access and refresh tokens are never included in command output, logs, or persisted snapshots.

## Undocumented endpoint risk

Both endpoints are undocumented Anthropic OAuth control-plane endpoints.
That means field shapes and availability can change without notice.

The implementation is designed to tolerate that:

- All response fields are optional.
- Missing or unrecognized fields are ignored rather than treated as zero usage.
- Unknown `limits[]` window types render with a useful fallback label rather than failing.
- `decimal_places` and minor-unit exponents are read from the response instead of hard-coded.
- If the profile endpoint fails, usage data still renders with a warning because enrichment is best-effort.
- If a token refresh fails mid-session, the last successful snapshot is shown as stale instead of clearing the display.
- HTTP errors including 401, 403, 429, and 5xx responses produce user-facing messages without crashing the command.

This follows the same defensive philosophy used by the request-shaping layer: patch the smallest proven surface and degrade gracefully rather than assuming stability.

If Anthropic changes these endpoints in a breaking way, the command will fail with an explicit error message while the rest of the extension — provider override, OAuth shaping, and `/anthropic-auth:status` — remains unaffected.

## Requirements

The Extra Usage tab shows credit and spend data only when Usage credits are enabled on the Anthropic account.
When they are off, Anthropic does not return credit or spend fields and the tab displays no data.
Users can enable Usage credits in the Anthropic Console under Settings → Plans & Billing → Usage credits.

## Compatibility and failure behavior

The feature is additive and does not replace Pi's built-in Anthropic transport.

Missing OAuth credentials, API-key authentication, authorization failures, rate limits, server errors, and malformed responses produce user-facing errors without exposing credentials.

If profile enrichment fails, usage data remains available with a warning.

If a refresh fails after a successful fetch, the last successful snapshot remains visible and is marked stale instead of displaying zero usage.

## Validation

- `vitest run` passed: 91 tests across 12 test files.
- `tsc --noEmit` passed.
- `eslint .` passed.
- `biome check .` passes for all changed files, with one pre-existing import-order error remaining in untouched `test/usage-client.test.ts`.
- `rumdl check PR.md` passed.
- The local `pnpm` wrapper could not run because its native binary integrity entry is missing from `pnpm-lock.yaml`; equivalent binaries were run directly from `node_modules/.bin`.
