### PR TITLE
fix: support Claude Fable 5.1 OAuth requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ If you have previously run `/login anthropic` and credentials are stored in `~/.
 
 To use the API key instead, run `/logout anthropic` inside Pi to remove the stored credentials, or delete `auth.json` before starting the session.
 
+### Anthropic rejects a new model because the Claude Code version is old
+
+The package sends a tested Claude Code version in the OAuth billing header.
+Anthropic can require a newer version before this package publishes an update.
+
+Set `PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION` to an installed Claude Code version:
+
+```bash
+export PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION="$(claude --version | grep -Eo '^[0-9]+\.[0-9]+\.[0-9]+')"
+pi
+```
+
+The value must use the `X.Y.Z` format.
+
 ### Docker: extension missing after volume mount
 
 If you install the extension at image build time with `RUN pi install npm:@gotgenes/pi-anthropic-auth` and then mount a persistent volume over `~/.pi/agent` at runtime, Docker may mask the build-time install.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -61,7 +61,24 @@ export const MINIMAL_ANTHROPIC_OAUTH_PROMPT = [
  * too far from what Anthropic expects, OAuth requests may be rejected or
  * counted incorrectly.
  */
-export const CLAUDE_CODE_VERSION = "2.1.206";
+export const CLAUDE_CODE_VERSION = "2.1.258";
+
+export const CLAUDE_CODE_VERSION_ENV = "PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION";
+
+export function resolveClaudeCodeVersion(
+  environment: NodeJS.ProcessEnv = process.env,
+): string {
+  const configuredVersion = environment[CLAUDE_CODE_VERSION_ENV];
+  if (configuredVersion === undefined || configuredVersion === "") {
+    return CLAUDE_CODE_VERSION;
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(configuredVersion)) {
+    throw new Error(
+      `${CLAUDE_CODE_VERSION_ENV} must use the X.Y.Z format, received ${JSON.stringify(configuredVersion)}`,
+    );
+  }
+  return configuredVersion;
+}
 
 /** Salt used in the billing header suffix hash. */
 export const BILLING_HEADER_SALT = "59cf53e54c78";

--- a/src/request-shaping.ts
+++ b/src/request-shaping.ts
@@ -3,7 +3,7 @@ import {
   BILLING_HEADER_POSITIONS,
   BILLING_HEADER_SALT,
   CLAUDE_CODE_ENTRYPOINT,
-  CLAUDE_CODE_VERSION,
+  resolveClaudeCodeVersion,
 } from "./constants";
 import { debugLog, isToolUseOnlyDebugEnabled } from "./debug";
 import { shapeSystemBlocks } from "./system-prompt-shaping";
@@ -75,6 +75,7 @@ function buildBillingHeaderValue(messages: MessageParam[]): string | undefined {
     return undefined;
   }
 
+  const claudeCodeVersion = resolveClaudeCodeVersion();
   const cch = createHash("sha256")
     .update(messageText)
     .digest("hex")
@@ -83,13 +84,13 @@ function buildBillingHeaderValue(messages: MessageParam[]): string | undefined {
     (index) => messageText[index] || "0",
   ).join("");
   const suffix = createHash("sha256")
-    .update(`${BILLING_HEADER_SALT}${sampledCharacters}${CLAUDE_CODE_VERSION}`)
+    .update(`${BILLING_HEADER_SALT}${sampledCharacters}${claudeCodeVersion}`)
     .digest("hex")
     .slice(0, 3);
 
   return [
     "x-anthropic-billing-header:",
-    `cc_version=${CLAUDE_CODE_VERSION}.${suffix};`,
+    `cc_version=${claudeCodeVersion}.${suffix};`,
     `cc_entrypoint=${CLAUDE_CODE_ENTRYPOINT};`,
     `cch=${cch};`,
   ].join(" ");

--- a/test/request-shaping.test.ts
+++ b/test/request-shaping.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { test } from "vitest";
+import { onTestFinished, test } from "vitest";
 
 import {
   BILLING_HEADER_POSITIONS,
@@ -83,6 +83,46 @@ test("returns non-anthropic-messages payloads unchanged", () => {
   const payload = { not: "an anthropic payload" };
 
   assert.equal(shapeAnthropicOAuthPayload(payload), payload);
+});
+
+test("uses a configured Claude Code version in the billing header", () => {
+  const variable = "PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION";
+  const previous = process.env[variable];
+  process.env[variable] = "2.1.300";
+  onTestFinished(() => {
+    if (previous === undefined) {
+      delete process.env.PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION;
+      return;
+    }
+    process.env[variable] = previous;
+  });
+
+  const payload = createOAuthPayload();
+  const shaped = shapeAnthropicOAuthPayload(payload) as typeof payload;
+  const systemBlocks = shaped.system as Array<{ text: string }>;
+
+  assert.match(
+    systemBlocks[0]?.text ?? "",
+    /cc_version=2\.1\.300\.[a-f0-9]{3};/,
+  );
+});
+
+test("rejects an invalid configured Claude Code version", () => {
+  const variable = "PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION";
+  const previous = process.env[variable];
+  process.env[variable] = "latest";
+  onTestFinished(() => {
+    if (previous === undefined) {
+      delete process.env.PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION;
+      return;
+    }
+    process.env[variable] = previous;
+  });
+
+  assert.throws(
+    () => shapeAnthropicOAuthPayload(createOAuthPayload()),
+    /PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION must use the X\.Y\.Z format/,
+  );
 });
 
 test("prepends the billing header block without adding cache control on OAuth payloads", () => {


### PR DESCRIPTION
## Summary

- Update the default Claude Code billing version from 2.1.206 to 2.1.258.
- Add a validated `PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION` override for future version gates.
- Document the override and test both valid and invalid values.

## Validation

- `pnpm test`
- `pnpm run check`
- `pnpm run lint`
- `pnpm fallow:audit`
- Live Pi request to `anthropic/claude-fable-5-1` returned `OK` through the local extension.

Closes #60