### PR TITLE
fix: honor the installed Claude Code version

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,6 +99,7 @@ Current source layout:
 5. `src/system-prompt-shaping.ts`: anchor-driven Anthropic OAuth prompt sanitizer that replaces Pi's identity paragraph and preserves tool snippets, guidelines, and appended content
 6. `src/debug.ts`: opt-in structured debug logging for live OAuth repros
 7. `src/diagnostics.ts`: `ExtensionDiagnostics` value object, formatter, and handler factory for the `/anthropic-auth:status` command
+8. `src/type-guards.ts`: shared runtime guards for values crossing provider transport boundaries
 
 ### Project Skills
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ pi-anthropic-auth diagnostics
 The `module` line shows which copy of the extension loaded.
 If the command is not found, the extension is not loaded at all.
 
+### Match the installed Claude Code version
+
+Set `PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION` when the billing header must match
+a pinned Claude Code installation exactly:
+
+```bash
+export PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION="$(claude --version | awk '{print $1}')"
+```
+
+`ANTHROPIC_CLI_VERSION` is also supported for compatibility with other Claude
+auth extensions. The package-specific variable takes precedence when both are
+set. When both are unset or empty, the extension uses its bundled fallback
+version.
+
 ### `ANTHROPIC_API_KEY` is ignored when OAuth credentials exist
 
 Pi's auth resolver gives stored credentials priority over environment variables.

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -47,10 +47,9 @@ export const MINIMAL_ANTHROPIC_OAUTH_PROMPT = [
 // OAuth requests.  They must match the values Anthropic's backend expects for
 // the current Claude Code release.
 //
-// CLAUDE_CODE_VERSION must be updated when Anthropic ships a new Claude Code
-// version.  There is no upstream source to import it from; check the current
-// version at https://github.com/anthropics/claude-code or in a working Claude
-// Code installation (`claude --version`) -- confirm even when a value is handed to you.
+// An environment override can track a pinned Claude Code installation exactly.
+// The fallback keeps existing behavior for users who do not manage the CLI
+// version themselves.
 // ---------------------------------------------------------------------------
 
 /**
@@ -61,7 +60,25 @@ export const MINIMAL_ANTHROPIC_OAUTH_PROMPT = [
  * too far from what Anthropic expects, OAuth requests may be rejected or
  * counted incorrectly.
  */
-export const CLAUDE_CODE_VERSION = "2.1.206";
+export const CLAUDE_CODE_VERSION = "2.1.259";
+
+type Environment = Readonly<Record<string, string | undefined>>;
+
+const CLAUDE_CODE_VERSION_ENV_NAMES = [
+  "PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION",
+  "ANTHROPIC_CLI_VERSION",
+] as const;
+
+export function resolveClaudeCodeVersion(
+  env: Environment = (globalThis as { process?: { env?: Environment } }).process
+    ?.env ?? {},
+): string {
+  for (const name of CLAUDE_CODE_VERSION_ENV_NAMES) {
+    const configuredVersion = env[name]?.trim();
+    if (configuredVersion?.length) return configuredVersion;
+  }
+  return CLAUDE_CODE_VERSION;
+}
 
 /** Salt used in the billing header suffix hash. */
 export const BILLING_HEADER_SALT = "59cf53e54c78";

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -70,8 +70,7 @@ const CLAUDE_CODE_VERSION_ENV_NAMES = [
 ] as const;
 
 export function resolveClaudeCodeVersion(
-  env: Environment = (globalThis as { process?: { env?: Environment } }).process
-    ?.env ?? {},
+  env: Environment = process.env,
 ): string {
   for (const name of CLAUDE_CODE_VERSION_ENV_NAMES) {
     const configuredVersion = env[name]?.trim();

--- a/src/oauth-transport.ts
+++ b/src/oauth-transport.ts
@@ -17,6 +17,10 @@ import { shapeAnthropicOAuthPayload } from "./request-shaping";
  */
 const ANTHROPIC_OAUTH_TOKEN_MARKER = "sk-ant-oat";
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
 /**
  * The `streamSimple` handler shape Pi's `ProviderConfig` accepts.
  *
@@ -97,7 +101,7 @@ export function createAnthropicOAuthStreamSimple(
         ? ((await callerOnPayload(payload, payloadModel)) ?? payload)
         : payload;
 
-      if (!isAnthropicOAuthToken(options?.apiKey)) {
+      if (!isAnthropicOAuthToken(options?.apiKey) || !isRecord(upstream)) {
         return upstream;
       }
 

--- a/src/oauth-transport.ts
+++ b/src/oauth-transport.ts
@@ -7,6 +7,7 @@ import type {
 } from "@earendil-works/pi-ai";
 import type { AnthropicStreamSimpleDelegate } from "./host-transport";
 import { shapeAnthropicOAuthPayload } from "./request-shaping";
+import { isRecord } from "./type-guards";
 
 /**
  * Anthropic OAuth access tokens are issued with an `sk-ant-oat` prefix.
@@ -16,10 +17,6 @@ import { shapeAnthropicOAuthPayload } from "./request-shaping";
  * our shaping aligned with Pi's own OAuth detection.
  */
 const ANTHROPIC_OAUTH_TOKEN_MARKER = "sk-ant-oat";
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 /**
  * The `streamSimple` handler shape Pi's `ProviderConfig` accepts.

--- a/src/request-shaping.ts
+++ b/src/request-shaping.ts
@@ -7,6 +7,7 @@ import {
 } from "./constants";
 import { debugLog, isToolUseOnlyDebugEnabled } from "./debug";
 import { shapeSystemBlocks } from "./system-prompt-shaping";
+import { isRecord } from "./type-guards";
 
 type TextBlock = {
   type: "text";
@@ -36,10 +37,6 @@ type AnthropicPayload = {
   stream?: unknown;
   [key: string]: unknown;
 };
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === "object" && !Array.isArray(value);
-}
 
 function isAnthropicMessagesPayload(
   payload: Record<string, unknown>,

--- a/src/request-shaping.ts
+++ b/src/request-shaping.ts
@@ -3,7 +3,7 @@ import {
   BILLING_HEADER_POSITIONS,
   BILLING_HEADER_SALT,
   CLAUDE_CODE_ENTRYPOINT,
-  CLAUDE_CODE_VERSION,
+  resolveClaudeCodeVersion,
 } from "./constants";
 import { debugLog, isToolUseOnlyDebugEnabled } from "./debug";
 import { shapeSystemBlocks } from "./system-prompt-shaping";
@@ -27,10 +27,12 @@ type MessageParam = {
   [key: string]: unknown;
 };
 
+type AnthropicSystem = string | unknown[] | null | undefined;
+
 type AnthropicPayload = {
   model?: unknown;
   messages?: unknown;
-  system?: unknown;
+  system?: AnthropicSystem;
   stream?: unknown;
   [key: string]: unknown;
 };
@@ -40,13 +42,17 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isAnthropicMessagesPayload(
-  payload: unknown,
+  payload: Record<string, unknown>,
 ): payload is AnthropicPayload {
+  const system = payload.system;
   return (
-    isRecord(payload) &&
     typeof payload.model === "string" &&
     Array.isArray(payload.messages) &&
-    typeof payload.stream === "boolean"
+    typeof payload.stream === "boolean" &&
+    (system === undefined ||
+      system === null ||
+      typeof system === "string" ||
+      Array.isArray(system))
   );
 }
 
@@ -82,14 +88,15 @@ function buildBillingHeaderValue(messages: MessageParam[]): string | undefined {
   const sampledCharacters = BILLING_HEADER_POSITIONS.map(
     (index) => messageText[index] || "0",
   ).join("");
+  const claudeCodeVersion = resolveClaudeCodeVersion();
   const suffix = createHash("sha256")
-    .update(`${BILLING_HEADER_SALT}${sampledCharacters}${CLAUDE_CODE_VERSION}`)
+    .update(`${BILLING_HEADER_SALT}${sampledCharacters}${claudeCodeVersion}`)
     .digest("hex")
     .slice(0, 3);
 
   return [
     "x-anthropic-billing-header:",
-    `cc_version=${CLAUDE_CODE_VERSION}.${suffix};`,
+    `cc_version=${claudeCodeVersion}.${suffix};`,
     `cc_entrypoint=${CLAUDE_CODE_ENTRYPOINT};`,
     `cch=${cch};`,
   ].join(" ");
@@ -112,9 +119,9 @@ function normalizeSystemBlock(block: unknown): TextBlock {
 }
 
 function prependBillingHeader(
-  system: unknown,
+  system: AnthropicSystem,
   messages: MessageParam[],
-): unknown {
+): AnthropicSystem {
   const billingHeader = buildBillingHeaderValue(messages);
   if (!billingHeader) {
     return system;
@@ -233,7 +240,9 @@ function shouldLogRequestDebug(messages: MessageParam[]): boolean {
  * sniff system-prompt markers here; non-Anthropic-messages payloads are still
  * returned untouched as a structural guard.
  */
-export function shapeAnthropicOAuthPayload(payload: unknown): unknown {
+export function shapeAnthropicOAuthPayload(
+  payload: Record<string, unknown>,
+): Record<string, unknown> {
   if (!isAnthropicMessagesPayload(payload)) {
     return payload;
   }

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -1,0 +1,3 @@
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}

--- a/test/oauth-transport.test.ts
+++ b/test/oauth-transport.test.ts
@@ -154,6 +154,15 @@ describe("createAnthropicOAuthStreamSimple", () => {
     );
   });
 
+  test("leaves non-record OAuth payloads untouched", async () => {
+    wrapped(MODEL, CONTEXT, { apiKey: OAUTH_TOKEN });
+
+    const input = "unrecognized provider payload";
+    const result = await resolveOnPayload(calls)(input, MODEL);
+
+    assert.equal(result, input);
+  });
+
   test("composes a caller-provided onPayload before shaping", async () => {
     const callerOnPayload: SimpleStreamOptions["onPayload"] = (payload) => {
       const next = payload as ReturnType<typeof samplePayload>;

--- a/test/request-shaping.test.ts
+++ b/test/request-shaping.test.ts
@@ -1,10 +1,11 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { test } from "vitest";
+import { onTestFinished, test } from "vitest";
 
 import {
   BILLING_HEADER_POSITIONS,
   BILLING_HEADER_SALT,
+  CLAUDE_CODE_VERSION,
   resolveClaudeCodeVersion,
 } from "#src/constants";
 import { shapeAnthropicOAuthPayload } from "#src/request-shaping";
@@ -108,40 +109,49 @@ test("prepends the billing header block without adding cache control on OAuth pa
   assert.equal(shaped["anthropic-beta"], "existing-beta");
 });
 
-test("uses ANTHROPIC_CLI_VERSION for the billing header", () => {
-  const previousVersion = process.env.ANTHROPIC_CLI_VERSION;
-  process.env.ANTHROPIC_CLI_VERSION = "2.1.259";
-
-  try {
-    const payload = createOAuthPayload();
-    const shaped = shapeAnthropicOAuthPayload(payload) as typeof payload;
-    const systemBlocks = shaped.system as Array<{ text: string }>;
-
-    assert.equal(
-      systemBlocks[0]?.text,
-      buildExpectedBillingHeader(
-        "Please summarize this repository status.",
-        "2.1.259",
-      ),
-    );
-    assert.equal(
-      resolveClaudeCodeVersion({ ANTHROPIC_CLI_VERSION: " 2.1.259 " }),
-      "2.1.259",
-    );
-    assert.equal(
-      resolveClaudeCodeVersion({
-        PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION: "2.1.300",
-        ANTHROPIC_CLI_VERSION: "2.1.259",
-      }),
-      "2.1.300",
-    );
-  } finally {
+test("uses the package version override for the billing header", () => {
+  const previousVersion = process.env.PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION;
+  process.env.PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION = "2.1.300";
+  onTestFinished(() => {
     if (previousVersion === undefined) {
-      delete process.env.ANTHROPIC_CLI_VERSION;
+      delete process.env.PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION;
     } else {
-      process.env.ANTHROPIC_CLI_VERSION = previousVersion;
+      process.env.PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION = previousVersion;
     }
-  }
+  });
+
+  const payload = createOAuthPayload();
+  const shaped = shapeAnthropicOAuthPayload(payload) as typeof payload;
+  const systemBlocks = shaped.system as Array<{ text: string }>;
+
+  assert.equal(
+    systemBlocks[0]?.text,
+    buildExpectedBillingHeader(
+      "Please summarize this repository status.",
+      "2.1.300",
+    ),
+  );
+});
+
+test("resolves Claude Code version overrides in precedence order", () => {
+  assert.equal(
+    resolveClaudeCodeVersion({ ANTHROPIC_CLI_VERSION: " 2.1.259 " }),
+    "2.1.259",
+  );
+  assert.equal(
+    resolveClaudeCodeVersion({
+      PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION: "2.1.300",
+      ANTHROPIC_CLI_VERSION: "2.1.259",
+    }),
+    "2.1.300",
+  );
+  assert.equal(
+    resolveClaudeCodeVersion({
+      PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION: "  ",
+      ANTHROPIC_CLI_VERSION: "",
+    }),
+    CLAUDE_CODE_VERSION,
+  );
 });
 
 test("does not add anthropic-beta to the request body when it is absent", () => {

--- a/test/request-shaping.test.ts
+++ b/test/request-shaping.test.ts
@@ -5,13 +5,16 @@ import { test } from "vitest";
 import {
   BILLING_HEADER_POSITIONS,
   BILLING_HEADER_SALT,
-  CLAUDE_CODE_VERSION,
+  resolveClaudeCodeVersion,
 } from "#src/constants";
 import { shapeAnthropicOAuthPayload } from "#src/request-shaping";
 
 const TEST_MODEL = "claude-haiku-4-5";
 
-function buildExpectedBillingHeader(messageText: string): string {
+function buildExpectedBillingHeader(
+  messageText: string,
+  claudeCodeVersion = resolveClaudeCodeVersion(),
+): string {
   const cch = createHash("sha256")
     .update(messageText)
     .digest("hex")
@@ -20,13 +23,13 @@ function buildExpectedBillingHeader(messageText: string): string {
     (index) => messageText[index] || "0",
   ).join("");
   const suffix = createHash("sha256")
-    .update(`${BILLING_HEADER_SALT}${sampledCharacters}${CLAUDE_CODE_VERSION}`)
+    .update(`${BILLING_HEADER_SALT}${sampledCharacters}${claudeCodeVersion}`)
     .digest("hex")
     .slice(0, 3);
 
   return [
     "x-anthropic-billing-header:",
-    `cc_version=${CLAUDE_CODE_VERSION}.${suffix};`,
+    `cc_version=${claudeCodeVersion}.${suffix};`,
     "cc_entrypoint=sdk-cli;",
     `cch=${cch};`,
   ].join(" ");
@@ -103,6 +106,42 @@ test("prepends the billing header block without adding cache control on OAuth pa
   assert.equal(systemBlocks[0]?.cache_control, undefined);
   assert.equal(systemBlocks[1]?.text, payload.system[0]?.text);
   assert.equal(shaped["anthropic-beta"], "existing-beta");
+});
+
+test("uses ANTHROPIC_CLI_VERSION for the billing header", () => {
+  const previousVersion = process.env.ANTHROPIC_CLI_VERSION;
+  process.env.ANTHROPIC_CLI_VERSION = "2.1.259";
+
+  try {
+    const payload = createOAuthPayload();
+    const shaped = shapeAnthropicOAuthPayload(payload) as typeof payload;
+    const systemBlocks = shaped.system as Array<{ text: string }>;
+
+    assert.equal(
+      systemBlocks[0]?.text,
+      buildExpectedBillingHeader(
+        "Please summarize this repository status.",
+        "2.1.259",
+      ),
+    );
+    assert.equal(
+      resolveClaudeCodeVersion({ ANTHROPIC_CLI_VERSION: " 2.1.259 " }),
+      "2.1.259",
+    );
+    assert.equal(
+      resolveClaudeCodeVersion({
+        PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION: "2.1.300",
+        ANTHROPIC_CLI_VERSION: "2.1.259",
+      }),
+      "2.1.300",
+    );
+  } finally {
+    if (previousVersion === undefined) {
+      delete process.env.ANTHROPIC_CLI_VERSION;
+    } else {
+      process.env.ANTHROPIC_CLI_VERSION = previousVersion;
+    }
+  }
 });
 
 test("does not add anthropic-beta to the request body when it is absent", () => {


### PR DESCRIPTION
## Summary

- update the bundled Claude Code fallback from 2.1.206 to 2.1.259
- resolve the billing-header version at request time from `PI_ANTHROPIC_AUTH_CLAUDE_CODE_VERSION`, then `ANTHROPIC_CLI_VERSION`, before using the fallback
- document both overrides and cover precedence, fallback, billing-header integration, and non-record transport passthrough

## Why

Anthropic rejects Claude Fable 5.1 OAuth requests that identify as Claude Code older than 2.1.251. A runtime override lets users track a pinned local Claude Code installation without waiting for a package release whenever Anthropic raises that floor.

## Validation

- `pnpm run check`
- `pnpm run lint`
- `pnpm test` (62 tests)
- `pnpm fallow dead-code`
- live Anthropic OAuth request from Pi with Claude Code 2.1.259

Fixes #60